### PR TITLE
Remove second entry footer from content-page.php

### DIFF
--- a/content-page.php
+++ b/content-page.php
@@ -21,8 +21,6 @@
 		?>
 	</div><!-- .entry-content -->
 
-	<?php edit_post_link( __( 'Edit', '_s' ), '<footer class="entry-meta"><span class="edit-link">', '</span></footer>' ); ?>
-
 	<footer class="entry-footer">
 		<?php edit_post_link( __( 'Edit', '_s' ), '<span class="edit-link">', '</span>' ); ?>
 	</footer><!-- .entry-footer -->


### PR DESCRIPTION
Hi guys, 

Thanks for sharing this sass version of _s. I find it very useful. This is my first pull request so please let me know if I'm doing something wrong. My apologies if I am. 

This is a pull request to remove the old entry footer from content-page.php so that is matches _s. There are currently two "edit" links under pages. I think the second was introduced during a merge conflict about a month ago.

Cheers.
