### PR TITLE
update FontAwesome icon font script to 4.2 on MaxCDN

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -19,7 +19,7 @@ function _s_scripts() {
 
 	}
 
-	wp_register_style( 'font-awesome', '//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css', array(), $version );
+	wp_register_style( 'font-awesome', '//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css', array(), $version );
 	wp_enqueue_style( 'font-awesome' );
 	wp_register_style( 'google-fonts', '//fonts.googleapis.com/css?family=Open+Sans:300,400,700', array(), $version );
 	wp_enqueue_style( 'google-fonts' );


### PR DESCRIPTION
Font Awesome 4.2.0 utilizes MaxCDN hosting for their latest minified assets. Just updating to point our script to latest version and MaxCDN instead of previously CloudFlare.
