### PR TITLE
Updated posts navigation function

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -36,7 +36,7 @@ get_header(); ?>
 	
 				<?php endwhile; ?>
 	
-				<?php the_posts_navigation(); ?>
+				<?php posts_navigation(); ?>
 	
 			<?php else : ?>
 	

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,13 +7,13 @@
  * @package _s
  */
 
-if ( ! function_exists( 'the_posts_navigation' ) ) :
+if ( ! function_exists( 'posts_navigation' ) ) :
 /**
  * Display navigation to next/previous set of posts when applicable.
  *
  * @todo Remove this function when WordPress 4.3 is released.
  */
-function the_posts_navigation() {
+function posts_navigation() {
 	// Don't print empty markup if there's only one page.
 	if ( $GLOBALS['wp_query']->max_num_pages < 2 ) {
 		return;

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ get_header(); ?>
 	
 				<?php endwhile; ?>
 	
-				<?php the_posts_navigation(); ?>
+				<?php posts_navigation(); ?>
 	
 			<?php else : ?>
 	


### PR DESCRIPTION
the_posts_navigation() is now part of WordPress so updating this function won't change pagination/post navigation output. Changed name 'to posts_navigation()' to fix this (leaving off 'the'). Also updated references to the function in index.php and archive.php
