### PR TITLE
Add some spacing by default to icons added using the icon mixin

### DIFF
--- a/sass/utilities/mixins/_icon-font-awesome.scss
+++ b/sass/utilities/mixins/_icon-font-awesome.scss
@@ -75,6 +75,15 @@
             font-weight: normal;
             font-family: $font-icon;
         }
+
+        @if $position == 'before' or $position == 'before, &:after' {
+            margin-right: rem(6);
+        }
+
+        @if $position == 'after' or $position == 'before, &:after' {
+            margin-left: rem(6);
+        }
+        
         // Include any extra rules supplied for the pseudo-element
         @content;
     }


### PR DESCRIPTION
I don't know about you but I like my icons to have some space. Seems simplest to just add a margin. Why not add on by default? I know there could be a case for _not_ adding them also (hence the second PR from the icons variable update).

I chose a default that wasn't too big but gave a visual separation. Of course as with all CSS this can be taken over by just adding a margin left/right in @content... but I would imagine there would more often be a margin added than taken away? Thoughts?
