### PR TITLE
Fix error with wds_posts_navigation

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ get_header(); ?>
 
 				<?php endwhile; ?>
 
-				<?php wds_posts_navigation(); ?>
+				<?php the_posts_navigation(); ?>
 
 			<?php else : ?>
 


### PR DESCRIPTION
This PR prevents the site from throwing fatal errors due to an undefined function.
