### PR TITLE
Replace hardcoded footer copyright text with customizer copyright text

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -21,9 +21,7 @@
 		<div class="wrap">
 
 			<div class="site-info">
-				<a href="<?php echo esc_url( __( 'https://wordpress.org/', '_s' ) ); ?>"><?php printf( esc_html__( 'Proudly powered by %s', '_s' ), 'WordPress' ); ?></a>
-				<span class="sep"> | </span>
-				<?php printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="http://automattic.com/" rel="designer">Automattic</a>' ); ?>
+				<?php _s_do_copyright_text(); ?>
 			</div><!-- .site-info -->
 
 		</div><!-- .wrap -->

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -61,8 +61,7 @@ function _s_customize_register( $wp_customize ) {
     $wp_customize->add_setting(
         '_s_copyright_text',
         array(
-            'default'           => '',
-            'sanitize_callback' => '_s_sanitize_customizer_text'
+            'default'           => ''
         )
     );
     $wp_customize->add_control(
@@ -72,6 +71,7 @@ function _s_customize_register( $wp_customize ) {
             'description' => __( 'The copyright text will be displayed beneath the menu in the footer.', '_s' ),
             'section'     => '_s_footer_section',
             'type'        => 'text',
+            'sanitize'    => 'html'
         )
     );
 }

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -253,3 +253,20 @@ function _s_get_attachment_id_from_url( $attachment_url = '' ) {
 
 	return $attachment_id;
 }
+
+/**
+ * Echo the copyright text saved in the Customizer
+ */
+function _s_do_copyright_text() {
+
+	// Grab our customizer settings
+	$copyright_text = get_theme_mod( '_s_copyright_text' );
+
+	// Stop if there's nothing to display
+	if ( ! $copyright_text ) {
+		return;
+	}
+
+	// Echo the text
+	echo '<span class="copyright-text">' . wp_kses_post( $copyright_text ) . '</span>';
+}


### PR DESCRIPTION
Replaced the hardcoded footer text with the customizer footer copyright text.
