### PR TITLE
Switching conditionals to use uniform syntax

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
  * @package _s
  */
 
-if ( ! function_exists( '_s_setup' ) ) :
+if ( ! function_exists( '_s_setup' ) ) {
 /**
  * Sets up theme defaults and registers support for various WordPress features.
  *
@@ -72,7 +72,7 @@ function _s_setup() {
 	 * Enable support and set configuration options for
 	 * WDS Simple Page Builder.
 	 */
-	if ( class_exists( 'WDS_Simple_Page_Builder' ) && version_compare( WDS_Simple_Page_Builder::VERSION, '1.6', '>=' ) ) :
+	if ( class_exists( 'WDS_Simple_Page_Builder' ) && version_compare( WDS_Simple_Page_Builder::VERSION, '1.6', '>=' ) ) {
 
 		// Add theme support
 		add_theme_support( 'wds-simple-page-builder' );
@@ -100,9 +100,9 @@ function _s_setup() {
 			register_page_builder_area( $page_builder_area_slug, $page_builder_area );
 		}
 
-	endif;
+	}
 }
-endif; // _s_setup
+} // _s_setup
 add_action( 'after_setup_theme', '_s_setup' );
 
 /**


### PR DESCRIPTION
The other code files in inc/\* do not use the colon conditional syntax. Switching
it in this file as well to provide uniformity.
