### PR TITLE
Update header to display site icon from Customizer

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,6 +20,7 @@
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 
+<?php wp_site_icon(); ?>
 <?php wp_head(); ?>
 </head>
 


### PR DESCRIPTION
Add wp_site_icon() to header.php to allow for display of icon set in Customizer. New since 4.3: http://www.sitepoint.com/all-you-need-to-know-about-the-new-wordpress-site-icon-api/
