### PR TITLE
Remove IDs from content templates

### DIFF
--- a/404.php
+++ b/404.php
@@ -11,7 +11,7 @@ get_header(); ?>
 
 	<div class="wrap content-area">
 
-		<main id="main" class="site-main">
+		<main class="site-main">
 
 			<section class="error-404 not-found">
 				<header class="page-header">

--- a/archive.php
+++ b/archive.php
@@ -12,7 +12,7 @@ get_header(); ?>
 	<div class="wrap">
 
 		<div class="primary content-area">
-			<main id="main" class="site-main">
+			<main class="site-main">
 
 			<?php if ( have_posts() ) : ?>
 

--- a/buddypress.php
+++ b/buddypress.php
@@ -15,7 +15,7 @@ get_header(); ?>
 	<div class="wrap">
 
 		<div class="primary content-area">
-			<main id="main" class="site-main">
+			<main class="site-main">
 
 				<?php while ( have_posts() ) : the_post(); ?>
 

--- a/comments.php
+++ b/comments.php
@@ -20,7 +20,7 @@ if ( post_password_required() ) {
 }
 ?>
 
-<div id="comments" class="comments-area">
+<div class="comments-area">
 
 	<?php // You can start editing here -- including this comment! ?>
 
@@ -36,7 +36,7 @@ if ( post_password_required() ) {
 		</h2>
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through? ?>
-		<nav id="comment-nav-above" class="navigation comment-navigation" role="navigation">
+		<nav class="navigation comment-nav-above comment-navigation" role="navigation">
 			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', '_s' ); ?></h2>
 			<div class="nav-links">
 
@@ -57,7 +57,7 @@ if ( post_password_required() ) {
 		</ol><!-- .comment-list -->
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through? ?>
-		<nav id="comment-nav-below" class="navigation comment-navigation" role="navigation">
+		<nav class="navigation comment-nav-below comment-navigation" role="navigation">
 			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', '_s' ); ?></h2>
 			<div class="nav-links">
 

--- a/footer.php
+++ b/footer.php
@@ -17,7 +17,7 @@
 		<?php wds_page_builder_area( 'after_content' ); ?>
 	</div>
 
-	<footer id="colophon" class="site-footer">
+	<footer class="site-footer">
 		<div class="wrap">
 
 			<div class="site-info">

--- a/functions.php
+++ b/functions.php
@@ -136,7 +136,7 @@ function _s_widgets_init() {
 			'name'          => $sidebar_name,
 			'id'            => $sidebar_id,
 			'description'   => sprintf ( esc_html__( 'Widget area for %s', '_s' ), $sidebar_name ),
-			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+			'before_widget' => '<aside class="widget %2$s">',
 			'after_widget'  => '</aside>',
 			'before_title'  => '<h3 class="widget-title">',
 			'after_title'   => '</h3>',

--- a/header.php
+++ b/header.php
@@ -46,13 +46,12 @@
 				<?php endif; ?>
 			</div><!-- .site-branding -->
 
-			<nav id="site-navigation" class="main-navigation">
+			<nav class="site-navigation main-navigation">
 				<button class="menu-toggle" aria-controls="primary-menu"><?php _s_do_svg( array( 'icon' => 'bars', 'title' => 'Display Menu' ) ); ?><span class="menu-toggle-text"><?php esc_html_e( 'Menu', '_s' ); ?></span></button>
 				<?php
 					wp_nav_menu( array(
 						'theme_location' => 'primary',
-						'menu_id'        => 'primary-menu',
-						'menu_class'     => 'menu dropdown'
+						'menu_class'     => 'primary-menu menu dropdown'
 					) );
 				?>
 			</nav><!-- #site-navigation -->

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ get_header(); ?>
 	<div class="wrap">
 
 		<div class="primary content-area">
-			<main id="main" class="site-main">
+			<main class="site-main">
 
 			<?php if ( have_posts() ) : ?>
 

--- a/page.php
+++ b/page.php
@@ -17,7 +17,7 @@ get_header(); ?>
 	<div class="wrap">
 
 		<div class="primary content-area">
-			<main id="main" class="site-main">
+			<main class="site-main">
 
 				<?php while ( have_posts() ) : the_post(); ?>
 

--- a/search.php
+++ b/search.php
@@ -13,7 +13,7 @@ get_header(); ?>
 	<div class="wrap">
 
 		<section class="primary content-area">
-			<main id="main" class="site-main">
+			<main class="site-main">
 
 			<?php if ( have_posts() ) : ?>
 

--- a/single.php
+++ b/single.php
@@ -12,7 +12,7 @@ get_header(); ?>
 	<div class="wrap">
 
 		<div class="primary content-area">
-			<main id="main" class="site-main">
+			<main class="site-main">
 
 			<?php while ( have_posts() ) : the_post(); ?>
 

--- a/template-page-builder-only.php
+++ b/template-page-builder-only.php
@@ -10,7 +10,7 @@ get_header(); ?>
 	<div class="wrap">
 
 		<div class="primary content-area">
-			<main id="main" class="site-main">
+			<main class="site-main">
 
 				<?php wds_page_builder_load_parts(); ?>
 

--- a/template-parts/content-buddypress.php
+++ b/template-parts/content-buddypress.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article <?php post_class(); ?>>
 
 	<div class="entry-content">
 		<?php the_content(); ?>

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header><!-- .entry-header -->

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -4,7 +4,7 @@
  */
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -4,7 +4,7 @@
  */
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php the_title( sprintf( '<h1 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h1>' ); ?>
 


### PR DESCRIPTION
Ticket #142 

I've gone through and removed IDs.

I will note that I've kept 3 structural IDs intact within header.php:
- div#page
- div#masthead
- div#content
