### PR TITLE
Adds the youtube iframe jsapi to the modal js.

### DIFF
--- a/assets/scripts/concat/modal.js
+++ b/assets/scripts/concat/modal.js
@@ -93,3 +93,34 @@ window.wdsModal = {};
 	// Engage!
 	$( app.init );
 } )( window, jQuery, window.wdsModal );
+
+// Load the yt iframe api js file from youtube.
+// NOTE THE IFRAME URL MUST HAVE 'enablejsapi=1' appended to it.
+// example: src="http://www.youtube.com/embed/M7lc1UVf-VE?enablejsapi=1"
+var tag = document.createElement('script');
+tag.id = 'iframe-yt';
+tag.src = 'https://www.youtube.com/iframe_api';
+var firstScriptTag = document.getElementsByTagName('script')[0];
+firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+// This var and function have to be available globally due to yt js iframe api.
+var player;
+function onYouTubeIframeAPIReady() {
+	var modal = jQuery('div.modal-open');
+	var iframeid = modal.find('iframe').attr('id');
+
+	player = new YT.Player( iframeid , {
+		events: {
+			'onReady': onPlayerReady,
+			'onStateChange': onPlayerStateChange
+		}
+	});
+}
+
+function onPlayerReady(event) {
+
+}
+
+function onPlayerStateChange() {
+	jQuery( window ).focus();
+}


### PR DESCRIPTION
If an iframe containing a youtube video is the content in the body of a modal the iframe takes focus when a user clicks play.
Because the iframe has focus the keyboard accessibility does not function, specifically closing modal with escape key.
This update loads the youtube iframe jsapi library and targest the active player.
When a user clicks play the onStateChange event is fired and this returns focus to the primary window.
By returning focus the keyboard commands are respected.