### PR TITLE
Typo in desc, and size mixin updates

### DIFF
--- a/assets/sass/base/_accessibility.scss
+++ b/assets/sass/base/_accessibility.scss
@@ -4,10 +4,9 @@
 
 // Hide text meant only for screen readers
 .screen-reader-text {
-	@include size(rem(1) auto);
+	@include size(rem(1));
 
 	clip: rect(rem(1), rem(1), rem(1), rem(1));
-	height: rem(1);
 	overflow: hidden;
 	position: absolute;
 	white-space: nowrap; // do not smuch text in screen readers

--- a/assets/sass/base/_media.scss
+++ b/assets/sass/base/_media.scss
@@ -142,7 +142,7 @@ img {
 
 // Video as background
 .video-as-background {
-	@include size(100% 100%);
+	@include size(100%);
 
 	display: block;
 	object-fit: cover;

--- a/assets/sass/modules/_hero.scss
+++ b/assets/sass/modules/_hero.scss
@@ -24,7 +24,7 @@
 	// &:after {
 	// 	@include linear-gradient(to bottom, rgba($color-black, 0) 0%, rgba($color-black, 0.50) 50%);
 	// 	@include position(absolute, 0 0 null null);
-	// 	@include size(100% 100%);
+	// 	@include size(100%);
 
 	// 	content: '';
 	// 	z-index: 2;

--- a/assets/sass/modules/_hero.scss
+++ b/assets/sass/modules/_hero.scss
@@ -13,7 +13,7 @@
 	// Transparent overlay (optional).
 	&::after {
 		@include position(absolute, 0 0 null null);
-		@include size(100% 100%);
+		@include size(100%);
 
 		background-color: rgba($color-black, 0.6);
 		content: "";

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -2,7 +2,7 @@
 /**
  * Custom ACF functions.
  *
- * A place to custom funcdtionality related to Advanced Custom Fields.
+ * A place to custom functionality related to Advanced Custom Fields.
  *
  * @package _s
  */


### PR DESCRIPTION
I noticed the `size` mixin compiles with duplicate values if the w and h are the same when I used [their size mixin](https://github.com/thoughtbot/bourbon/blob/master/core/bourbon/library/_size.scss) from master: 

http://www.sassmeister.com/gist/38c909c75a0474e6b587b849f2beb800

But I also see on your CodePen demo of hero that it isn't doing that. I believe they are deprecating this mixin in V5 anyway, but thought this might be helpful in the meantime.
