### PR TITLE
Don't enforce 4 tab size.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,9 +16,7 @@ charset = utf-8
 # 4 space indentation
 [*.{html,js,php,css,scss}]
 indent_style = tab
-indent_size = 4
 
 # Matches the exact files
 [{package.json,bower.json,.bowerrc,.eslintrc.js,.travis.yml,.sass-lint.yml,phpcs.xml}]
 indent_style = space
-indent_size = 2


### PR DESCRIPTION
### DESCRIPTION ###


[This setting](https://github.com/WebDevStudios/wd_s/blob/master/.editorconfig#L19) makes my preferred tab size in Sublime, `2`, become `4`:

### SCREENSHOTS ###

![editrocontigno](https://user-images.githubusercontent.com/1753298/33396771-cd72ee3e-d506-11e7-9156-63c4e024b3cc.gif)

I don't think enforcing 4 tab size is a coding requirement, and should be left to the preference of the developer.