### PR TITLE
Remove duplicate @import 'footer'

### DIFF
--- a/assets/sass/modules/index.scss
+++ b/assets/sass/modules/index.scss
@@ -4,7 +4,6 @@
 @import 'content';
 @import 'content-blocks/index';
 @import 'footer';
-@import 'footer';
 @import 'forms';
 @import 'header';
 @import 'icons';


### PR DESCRIPTION
Closes #345 
In /assets/sass/modules/index.scss footer.scss is imported twice. This removes the duplicate import.