### PR TITLE
Fix link to contributors guidelines in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ From the command line, type any of the following to perform an action:
 
 ## Contributing and Support
 
-Your contributions and [support tickets](https://github.com/WebDevStudios/wd_s/issues) are welcome. Please see our [guidelines](https://github.com/WebDevStudios/wd_s/blob/master/CONTRIBUTING.md) before submitting a pull request.
+Your contributions and [support tickets](https://github.com/WebDevStudios/wd_s/issues) are welcome. Please see our [guidelines](https://github.com/WebDevStudios/wd_s/blob/master/.github/CONTRIBUTING.md) before submitting a pull request.


### PR DESCRIPTION
It seems like CONTRIBUTING.md was removed from root at some point but the README.md still links to it, returning a 404. I've changed the link to the file in the .github folder. 