### PR TITLE
Hotfix/#344 hidden subfields

### DIFF
--- a/acf-json/group_58ebcc07bfbd7.json
+++ b/acf-json/group_58ebcc07bfbd7.json
@@ -34,28 +34,18 @@
             "layout": "block",
             "sub_fields": [
                 {
-                    "ID": 6035,
-                    "key": "field_596d119808099",
+                    "key": "field_5ab3e6937bb9d",
                     "label": "Background Type",
                     "name": "background_type",
-                    "prefix": "acf",
                     "type": "select",
-                    "value": null,
-                    "menu_order": 0,
                     "instructions": "Choose a type of background.",
                     "required": 0,
-                    "id": "",
-                    "class": "",
                     "conditional_logic": 0,
-                    "parent": 6034,
                     "wrapper": {
                         "width": "",
                         "class": "",
                         "id": ""
                     },
-                    "_name": "background_type",
-                    "_prepare": 0,
-                    "_valid": 1,
                     "choices": {
                         "null": "None",
                         "color": "Color",
@@ -65,75 +55,55 @@
                     "default_value": [],
                     "allow_null": 0,
                     "multiple": 0,
-                    "ui": 1,
+                    "ui": 0,
                     "ajax": 0,
                     "return_format": "array",
                     "placeholder": ""
                 },
                 {
-                    "ID": 5827,
-                    "key": "field_58ebcd698512e",
+                    "key": "field_5ab3e6cc7bb9e",
                     "label": "Background Color",
                     "name": "background_color",
-                    "prefix": "acf",
                     "type": "color_picker",
-                    "value": null,
-                    "menu_order": 1,
                     "instructions": "Select a background color.",
                     "required": 0,
-                    "id": "",
-                    "class": "",
                     "conditional_logic": [
                         [
                             {
-                                "field": "field_596d119808099",
+                                "field": "field_5ab3e6937bb9d",
                                 "operator": "==",
                                 "value": "color"
                             }
                         ]
                     ],
-                    "parent": 6034,
                     "wrapper": {
                         "width": "",
                         "class": "",
                         "id": ""
                     },
-                    "_name": "background_color",
-                    "_prepare": 0,
-                    "_valid": 1,
                     "default_value": ""
                 },
                 {
-                    "ID": 5828,
-                    "key": "field_58ebcda08512f",
+                    "key": "field_5ab3e6e67bb9f",
                     "label": "Background Image",
                     "name": "background_image",
-                    "prefix": "acf",
                     "type": "image",
-                    "value": null,
-                    "menu_order": 2,
                     "instructions": "Add\/Upload an image file. (1920x1080px .jpg, .png)",
                     "required": 0,
-                    "id": "",
-                    "class": "",
                     "conditional_logic": [
                         [
                             {
-                                "field": "field_596d119808099",
+                                "field": "field_5ab3e6937bb9d",
                                 "operator": "==",
                                 "value": "image"
                             }
                         ]
                     ],
-                    "parent": 6034,
                     "wrapper": {
                         "width": "",
                         "class": "",
                         "id": ""
                     },
-                    "_name": "background_image",
-                    "_prepare": 0,
-                    "_valid": 1,
                     "return_format": "array",
                     "preview_size": "medium",
                     "library": "all",
@@ -146,36 +116,26 @@
                     "mime_types": "jpg, png"
                 },
                 {
-                    "ID": 5829,
-                    "key": "field_59416a7edea96",
+                    "key": "field_5ab3e72e7bba0",
                     "label": "Background Video",
                     "name": "background_video",
-                    "prefix": "acf",
                     "type": "file",
-                    "value": null,
-                    "menu_order": 3,
-                    "instructions": "Add\/Upload a 1920x1080 .mp4 video file. Note: background videos are only supported on hero's.",
+                    "instructions": "Add\/Upload a 1920x1080 .mp4 video file. Note: background videos are only supported on Hero blocks.",
                     "required": 0,
-                    "id": "",
-                    "class": "",
                     "conditional_logic": [
                         [
                             {
-                                "field": "field_596d119808099",
+                                "field": "field_5ab3e6937bb9d",
                                 "operator": "==",
                                 "value": "video"
                             }
                         ]
                     ],
-                    "parent": 6034,
                     "wrapper": {
                         "width": "",
                         "class": "",
                         "id": ""
                     },
-                    "_name": "background_video",
-                    "_prepare": 0,
-                    "_valid": 1,
                     "return_format": "array",
                     "library": "all",
                     "min_size": "",
@@ -194,7 +154,7 @@
             }
         ]
     ],
-    "menu_order": "",
+    "menu_order": 0,
     "position": "normal",
     "style": "default",
     "label_placement": "top",
@@ -202,5 +162,5 @@
     "hide_on_screen": "",
     "active": 0,
     "description": "",
-    "modified": 1500321726
+    "modified": 1521739612
 }

--- a/acf-json/group_594168e970d85.json
+++ b/acf-json/group_594168e970d85.json
@@ -34,53 +34,33 @@
             "layout": "block",
             "sub_fields": [
                 {
-                    "ID": 5831,
-                    "key": "field_594168fa457bd",
+                    "key": "field_5ab3e485ab634",
                     "label": "Font Color",
                     "name": "font_color",
-                    "prefix": "acf",
                     "type": "color_picker",
-                    "value": null,
-                    "menu_order": 0,
                     "instructions": "Change the text color of this block.",
                     "required": 0,
-                    "id": "",
-                    "class": "",
                     "conditional_logic": 0,
-                    "parent": 6037,
                     "wrapper": {
                         "width": "50",
                         "class": "",
                         "id": ""
                     },
-                    "_name": "font_color",
-                    "_prepare": 0,
-                    "_valid": 1,
                     "default_value": ""
                 },
                 {
-                    "ID": 5832,
-                    "key": "field_5941ea778fe87",
+                    "key": "field_5ab3e4afab635",
                     "label": "Custom CSS Class",
                     "name": "custom_css_class",
-                    "prefix": "acf",
                     "type": "text",
-                    "value": null,
-                    "menu_order": 1,
                     "instructions": "Add a custom CSS class to this block.",
                     "required": 0,
-                    "id": "",
-                    "class": "",
                     "conditional_logic": 0,
-                    "parent": 6037,
                     "wrapper": {
                         "width": "50",
                         "class": "",
                         "id": ""
                     },
-                    "_name": "custom_css_class",
-                    "_prepare": 0,
-                    "_valid": 1,
                     "default_value": "",
                     "placeholder": "custom-class",
                     "prepend": "",
@@ -88,28 +68,18 @@
                     "maxlength": ""
                 },
                 {
-                    "ID": 6030,
-                    "key": "field_596cf9b68538d",
+                    "key": "field_5ab3e4c7ab636",
                     "label": "Animation",
                     "name": "animation",
-                    "prefix": "acf",
                     "type": "select",
-                    "value": null,
-                    "menu_order": 2,
                     "instructions": "Select the animation for this block. Animations can only be applied to the entire block, not to individual elements.",
                     "required": 0,
-                    "id": "",
-                    "class": "",
                     "conditional_logic": 0,
-                    "parent": 6037,
                     "wrapper": {
                         "width": "",
                         "class": "",
                         "id": ""
                     },
-                    "_name": "animation",
-                    "_prepare": 0,
-                    "_valid": 1,
                     "choices": {
                         "null": "None",
                         "bounce": "bounce",
@@ -192,7 +162,7 @@
                     "default_value": [],
                     "allow_null": 0,
                     "multiple": 0,
-                    "ui": 1,
+                    "ui": 0,
                     "ajax": 0,
                     "return_format": "value",
                     "placeholder": ""
@@ -209,7 +179,7 @@
             }
         ]
     ],
-    "menu_order": "",
+    "menu_order": 0,
     "position": "normal",
     "style": "default",
     "label_placement": "top",
@@ -217,5 +187,5 @@
     "hide_on_screen": "",
     "active": 0,
     "description": "",
-    "modified": 1500323207
+    "modified": 1521739116
 }


### PR DESCRIPTION
Closes #344 

### DESCRIPTION ###
- First, I went all the way back to ACF v5.6 and was unable to get the Group subfields to load, and I noticed when I created new fields (just to test) it was writing the JSON files slightly different that what we have.

- Sooo, I rebuilt both Group subfields from scratch, which generated what appears to be "updated" JSON file format. See the [diff file](https://github.com/WebDevStudios/wd_s/pull/348/files)...

- Finally, I copied/pasted these updated JSON files onto another project, and 💥 I was able to edit them!

### SCREENSHOTS ###
![screenshot](https://dl.dropbox.com/s/de8hyf4zys0wgvg/Screenshot%202018-03-22%2012.30.16.png?dl=0)

![screenshot](https://dl.dropbox.com/s/omp5urz9j3hmn4q/Screenshot%202018-03-22%2012.31.00.png?dl=0)

### STEPS TO VERIFY ###
Check out this PR, and sync the fields. You should be able to edit the Group sub-fields  now.