### PR TITLE
Hotfix/#343 password protect blocks

### DIFF
--- a/template-acf.php
+++ b/template-acf.php
@@ -13,7 +13,14 @@ get_header(); ?>
 
 	<div class="content-area">
 		<main id="main" class="site-main">
-		<?php _s_display_content_blocks(); ?>
+		<?php
+			// If the page is password protected...
+			if ( post_password_required() ) :
+				get_template_part( 'template-parts/content', 'password-protected' );
+			else :
+				_s_display_content_blocks();
+			endif;
+		?>
 		</main><!-- #main -->
 	</div><!-- .primary -->
 

--- a/template-parts/content-password-protected.php
+++ b/template-parts/content-password-protected.php
@@ -15,7 +15,9 @@
 		</header><!-- .entry-header -->
 
 		<div class="entry-content">
-			<?php echo get_the_password_form(); // WPCS XSS OK. ?>
+			<?php
+				echo get_the_password_form(); // WPCS XSS OK.
+			?>
 		</div><!-- .entry-content -->
 
 	</article><!-- #post-## -->

--- a/template-parts/content-password-protected.php
+++ b/template-parts/content-password-protected.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Template part for displaying the password protection form.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package _s
+ */
+
+?>
+<div class="grid-x">
+	<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+		<header class="entry-header">
+			<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+		</header><!-- .entry-header -->
+
+		<div class="entry-content">
+			<?php echo get_the_password_form(); // WPCS XSS OK. ?>
+		</div><!-- .entry-content -->
+
+	</article><!-- #post-## -->
+</div>


### PR DESCRIPTION
Closes #343 

### DESCRIPTION ###
- Wrapped our `_s_display_content_blocks()` function in `post_password_required()`. 
- I also created a template part so the password form would be in a container and not left aligned (which was a bit jarring)

### SCREENSHOTS ###
![screenshot](https://dl.dropbox.com/s/h75iivvkewew9vw/Screenshot%202018-03-23%2009.30.10.png?dl=0)

### STEPS TO VERIFY ###
- Check out this PR, and try to access a ACF page w/ Password Protection on.

### DOCUMENTATION ###
No.