### PR TITLE
Feature/acf block options universal use

### DIFF
--- a/acf-json/group_58ebcc07bfbd7.json
+++ b/acf-json/group_58ebcc07bfbd7.json
@@ -1,6 +1,6 @@
 {
     "key": "group_58ebcc07bfbd7",
-    "title": "Group: Background Options - To Clone",
+    "title": "Group: Background Options — To Clone",
     "fields": [
         {
             "key": "field_596d115a08097",
@@ -42,17 +42,19 @@
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
-                        "width": "",
+                        "width": "33",
                         "class": "",
                         "id": ""
                     },
                     "choices": {
-                        "null": "None",
+                        "none": "None",
                         "color": "Color",
                         "image": "Image",
                         "video": "Video"
                     },
-                    "default_value": [],
+                    "default_value": [
+                        "none"
+                    ],
                     "allow_null": 0,
                     "multiple": 0,
                     "ui": 0,
@@ -77,7 +79,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": "",
+                        "width": "66",
                         "class": "",
                         "id": ""
                     },
@@ -100,7 +102,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": "",
+                        "width": "66",
                         "class": "",
                         "id": ""
                     },
@@ -132,7 +134,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": "",
+                        "width": "66",
                         "class": "",
                         "id": ""
                     },
@@ -162,5 +164,5 @@
     "hide_on_screen": "",
     "active": 0,
     "description": "",
-    "modified": 1521739612
+    "modified": 1521824780
 }

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -33,10 +33,10 @@ function _s_display_content_blocks() {
 function _s_display_block_options( $args = array() ) {
 
 	// Get block background options.
-	$background_options = get_sub_field( 'background_options' );
+	$background_options = get_sub_field( 'background_options' ) ? get_sub_field( 'background_options' ) : get_field( 'background_options' )['background_options'];
 
 	// Get block other options.
-	$other_options = get_sub_field( 'other_options' );
+	$other_options = get_sub_field( 'other_options' ) ? get_sub_field( 'other_options' ) : get_field( 'other_options' )['other_options'];
 
 	// Setup defaults.
 	$defaults = array(

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -58,17 +58,17 @@ function _s_display_block_options( $args = array() ) {
 	if ( $args['background_type'] ) {
 		if ( 'color' === $args['background_type'] ) {
 			$background_color = $background_options['background_color'];
-			$inline_style .= 'background-color: ' . $background_color . '; ';
+			$inline_style    .= 'background-color: ' . $background_color . '; ';
 		}
 
 		if ( 'image' === $args['background_type'] ) {
 			$background_image = $background_options['background_image'];
-			$inline_style .= 'background-image: url(' . esc_url( $background_image['sizes']['full-width'] ) . ');';
-			$args['class'] .= ' image-as-background';
+			$inline_style    .= 'background-image: url(' . esc_url( $background_image['sizes']['full-width'] ) . ');';
+			$args['class']   .= ' image-as-background';
 		}
 
 		if ( 'video' === $args['background_type'] ) {
-			$background_video = $background_options['background_video'];
+			$background_video        = $background_options['background_video'];
 			$background_video_markup = '<video class="video-as-background" autoplay muted loop preload="auto"><source src="' . esc_url( $background_video['url'] ) . '" type="video/mp4"></video>';
 		}
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -92,10 +92,10 @@ function _s_get_placeholder_image( $args = array() ) {
 	$args = wp_parse_args( $args, $default_args );
 
 	// Extract the vars we want to work with.
-	$width = $args['width'];
-	$height = $args['height'];
+	$width            = $args['width'];
+	$height           = $args['height'];
 	$background_color = $args['background_color'];
-	$text_color = $args['text_color'];
+	$text_color       = $args['text_color'];
 
 	// Perform some quick data validation.
 	if ( ! is_numeric( $width ) ) {
@@ -177,7 +177,7 @@ function _s_get_placeholder_unsplash( $args = array() ) {
 	// Apply a category if desired.
 	if ( ! empty( $args['category'] ) ) {
 		$category = rawurlencode( $args['category'] );
-		$url .= "category/$category/";
+		$url     .= "category/$category/";
 	}
 
 	// Dimensions go after category but before search keywords.
@@ -185,7 +185,7 @@ function _s_get_placeholder_unsplash( $args = array() ) {
 
 	if ( ! empty( $args['keywords'] ) ) {
 		$keywords = rawurlencode( $args['keywords'] );
-		$url .= "?$keywords";
+		$url     .= "?$keywords";
 	}
 
 	// Text that will be utilized by screen readers.

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -77,7 +77,7 @@ function _s_category_transient_flusher() {
 	delete_transient( '_s_categories' );
 }
 add_action( 'delete_category', '_s_category_transient_flusher' );
-add_action( 'save_post',     '_s_category_transient_flusher' );
+add_action( 'save_post', '_s_category_transient_flusher' );
 
 /**
  * Customize "Read More" string on <!-- more --> with the_content();
@@ -105,7 +105,7 @@ add_filter( 'excerpt_more', '_s_excerpt_more' );
  * @return array Updated allowed mime types.
  */
 function _s_custom_mime_types( $mimes ) {
-	$mimes['svg'] = 'image/svg+xml';
+	$mimes['svg']  = 'image/svg+xml';
 	$mimes['svgz'] = 'image/svg+xml';
 	return $mimes;
 }

--- a/inc/scaffolding.php
+++ b/inc/scaffolding.php
@@ -17,12 +17,12 @@ function _s_display_scaffolding_section( $args = array() ) {
 
 	// Set defaults.
 	$defaults = array(
-		'title'        => '',       // The scaffolding title.
-		'description'  => '',       // The scaffolding description.
-		'usage'        => '',       // The template tag or markup needed to display the scaffolding.
-		'parameters'   => array(),  // Does the scaffolding have params? Like $args?
-		'arguments'    => array(),  // If the scaffolding has params, what are the $args?
-		'output'       => '',       // Use the template tag or scaffolding HTML markup here. It will be sanitized displayed.
+		'title'       => '',       // The scaffolding title.
+		'description' => '',       // The scaffolding description.
+		'usage'       => '',       // The template tag or markup needed to display the scaffolding.
+		'parameters'  => array(),  // Does the scaffolding have params? Like $args?
+		'arguments'   => array(),  // If the scaffolding has params, what are the $args?
+		'output'      => '',       // Use the template tag or scaffolding HTML markup here. It will be sanitized displayed.
 	);
 
 	// Parse arguments.
@@ -105,14 +105,14 @@ function _s_scaffolding_allowed_html() {
 
 	// Add additional HTML tags to the wp_kses() allowed html filter.
 	$allowed_tags = array_merge( wp_kses_allowed_html( 'post' ), array(
-		'svg' => array(
+		'svg'   => array(
 			'aria-hidden' => true,
 			'class'       => true,
 			'id'          => true,
 			'role'        => true,
 			'title'       => true,
 		),
-		'use' => array(
+		'use'   => array(
 			'xlink:href' => true,
 		),
 		'input' => array(
@@ -197,11 +197,10 @@ function _s_display_global_scaffolding_section( $args = array() ) {
 						<p><strong><?php echo esc_html( $font_var ); ?>:</strong> <span style="font-family: <?php echo esc_attr( $family ); ?>"><?php echo esc_html( $family ); ?></span></p>
 					<?php endforeach; ?>
 					</div>
-					<?php break; ?>
+				<?php break; ?>
 			<?php endswitch; ?>
 		</div>
 	</div>
-
 	<?php
 }
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -117,21 +117,22 @@ function _s_display_svg( $args = array() ) {
 
 	// Generate random IDs for the title and description.
 	$random_number = rand( 0, 99999 );
-	$title_id = 'title-' . sanitize_title( $title ) . '-' . $random_number;
-	$desc_id = 'desc-' . sanitize_title( $title ) . '-' . $random_number;
+	$title_id      = 'title-' . sanitize_title( $title ) . '-' . $random_number;
+	$desc_id       = 'desc-' . sanitize_title( $title ) . '-' . $random_number;
 
 	// Set ARIA.
-	$aria_hidden = ' aria-hidden="true"';
+	$aria_hidden     = ' aria-hidden="true"';
 	$aria_labelledby = '';
+
 	if ( $args['title'] && $args['desc'] ) {
 		$aria_labelledby = ' aria-labelledby="' . $title_id . ' ' . $desc_id . '"';
-		$aria_hidden = '';
+		$aria_hidden     = '';
 	}
 
 	// Set SVG parameters.
-	$fill = ( $args['fill'] ) ? ' fill="' . $args['fill'] . '"' : '';
+	$fill   = ( $args['fill'] ) ? ' fill="' . $args['fill'] . '"' : '';
 	$height = ( $args['height'] ) ? ' height="' . $args['height'] . '"' : '';
-	$width = ( $args['width'] ) ? ' width="' . $args['width'] . '"' : '';
+	$width  = ( $args['width'] ) ? ' width="' . $args['width'] . '"' : '';
 
 	// Start a buffer...
 	ob_start();
@@ -440,7 +441,7 @@ function _s_display_header_button() {
 	$button_setting = get_theme_mod( '_s_header_button' );
 
 	// If we have no button displayed, don't display the markup.
-	if ( 'none' == $button_setting ) {
+	if ( 'none' === $button_setting ) {
 		return '';
 	}
 
@@ -451,7 +452,7 @@ function _s_display_header_button() {
 	<div class="site-header-action">
 		<?php
 		// If we're doing a URL, just make this LOOK like a button but be a link.
-		if ( 'link' == $button_setting && $button_url ) :
+		if ( 'link' === $button_setting && $button_url ) :
 		?>
 			<a href="<?php echo esc_url( $button_url ); ?>" class="button button-link"><?php echo esc_html( $button_text ?: __( 'More Information', '_s' ) ); ?></a>
 		<?php else : ?>


### PR DESCRIPTION
### DESCRIPTION ###
Adds a simple ternary check to allow for the `_s_display_block_options` function to be used outside of the ACF Flexible Content block.

- https://github.com/WebDevStudios/wd_s/blob/feature/acf-block-options-universal-use/inc/acf.php#L36

This also lints the `inc` files to bring it up to date with the WDS standard.

Also changes the background type options from `null : None` to `none : None` which the `_s_display_block_options` function checks for, but fails — and sets the default as fallback.

- https://github.com/WebDevStudios/wd_s/blob/master/inc/acf.php#L75

![screenshot 2018-03-23 11 06 14](https://user-images.githubusercontent.com/5230729/37843376-55ba787a-2e8a-11e8-8183-6cc07b38e1a7.jpg)
