### PR TITLE
Change WDS Coding Standards to a dev dependency, update composer.lock.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "webdevstudios/wd_s",
     "description": "A theme boilerplate for WebDevStudios.",
     "type": "wordpress-theme",
-    "require": {
+    "require-dev": {
         "webdevstudios/wds-coding-standards": "^1.1"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b256ca44e6f23edde616266c267eace8",
-    "packages": [
+    "content-hash": "8fa92c5b8bf8c88ece2f30525503aa84",
+    "packages": [],
+    "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.1.1",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e"
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d667e245d5dcd4d7bf80f26f2c947d476b66213e",
-                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +28,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -55,42 +56,42 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-10-16T22:40:25+00:00"
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
             "name": "webdevstudios/wds-coding-standards",
-            "version": "1.1",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WebDevStudios/WDS-Coding-Standards.git",
-                "reference": "b3127be26e59631a6cbcc85e44ec34ec0473e39b"
+                "reference": "3d67233414fed3e519b59e38079033bf76389ba8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WebDevStudios/WDS-Coding-Standards/zipball/b3127be26e59631a6cbcc85e44ec34ec0473e39b",
-                "reference": "b3127be26e59631a6cbcc85e44ec34ec0473e39b",
+                "url": "https://api.github.com/repos/WebDevStudios/WDS-Coding-Standards/zipball/3d67233414fed3e519b59e38079033bf76389ba8",
+                "reference": "3d67233414fed3e519b59e38079033bf76389ba8",
                 "shasum": ""
             },
             "require": {
-                "wp-coding-standards/wpcs": "0.14.0"
+                "wp-coding-standards/wpcs": "0.14.1"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "description": "In-house linting and coding standards for WebDevStudios",
-            "time": "2017-12-08T19:45:27+00:00"
+            "time": "2018-03-23T21:09:55+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.0",
+            "version": "0.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c"
+                "reference": "cf6b310caad735816caef7573295f8a534374706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/8cadf48fa1c70b2381988e0a79e029e011a8f41c",
-                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
+                "reference": "cf6b310caad735816caef7573295f8a534374706",
                 "shasum": ""
             },
             "require": {
@@ -117,10 +118,9 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-11-01T15:10:46+00:00"
+            "time": "2018-02-16T01:57:48+00:00"
         }
     ],
-    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],


### PR DESCRIPTION
Closes #361 

### DESCRIPTION ###
- Updates WDS Coding Standards in composer.json to a dev dependency.

### SCREENSHOTS ###
n/a

### OTHER ###
This change has no effect on the theme itself - it will work the same as before.

- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [ ] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?

### STEPS TO VERIFY ###
1. Clone the repository.
2. Run `composer install --no-dev`.
3. Confirm that the vendor/ directory does neither WDS Coding Standards, WordPress Coding Standards, nor PHP Code Sniffer.
4. Run `composer install`.
5. Confirm that the vendor/ directory contains the aforementioned libraries.

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?
No