### PR TITLE
Hotfix/#368 scheduled block

### DIFF
--- a/inc/acf.php
+++ b/inc/acf.php
@@ -221,23 +221,27 @@ function _s_acf_flexible_content_layout_title( $title, $field, $layout, $i ) {
 	$other_options = get_sub_field( 'other_options' ) ? get_sub_field( 'other_options' ) : get_field( 'other_options' )['other_options'];
 
 	// Get Background Type.
-	$background          = get_sub_field( 'background_options' )['background_type']['value'];
-	$background_repeater = get_sub_field( 'hero_slides' )[0]['background_options']['background_type']['value'];
-	$background_type     = $background ? $background : $background_repeater;
+	$background = get_sub_field( 'background_options' )['background_type']['value'];
 
-	$type = _s_return_flexible_content_layout_value( $background_type );
+	// If there's no background, just move along...
+	if ( ! 'none' === $background ) {
+		$background_repeater = get_sub_field( 'hero_slides' )[0]['background_options']['background_type']['value'];
+		$background_type     = $background ? $background : $background_repeater;
 
-	// Load image from non-repeater sub field background image, if it exists else Load image from repeater sub field background image, if it exists — Hero.
-	if ( 'image' === $background_type ) {
-		$title .= '<img src="' . esc_url( $type['sizes']['thumbnail'] ) . '" height="30" width="30" class="acf-flexible-title-image" />';
-	}
+		$type = _s_return_flexible_content_layout_value( $background_type );
 
-	if ( 'color' === $background_type ) {
-		$title .= '<div style="background-color: ' . esc_attr( $type ) . '; height: 30px; width: 30px;" class="acf-flexible-title-image"><span class="screen-reader-text">' . esc_html( $type ) . '</span></div>';
-	}
+		// Load image from non-repeater sub field background image, if it exists else Load image from repeater sub field background image, if it exists — Hero.
+		if ( 'image' === $background_type ) {
+			$title .= '<img src="' . esc_url( $type['sizes']['thumbnail'] ) . '" height="30" width="30" class="acf-flexible-title-image" />';
+		}
 
-	if ( 'video' === $background_type ) {
-		$title .= '<div style="font-size: 30px; height: 26px; width: 30px;" class="dashicons dashicons-format-video acf-flexible-title-image"><span class="screen-reader-text">' . esc_html__( 'Video', '_s' ) . '</span></div>';
+		if ( 'color' === $background_type ) {
+			$title .= '<div style="background-color: ' . esc_attr( $type ) . '; height: 30px; width: 30px;" class="acf-flexible-title-image"><span class="screen-reader-text">' . esc_html( $type ) . '</span></div>';
+		}
+
+		if ( 'video' === $background_type ) {
+			$title .= '<div style="font-size: 30px; height: 26px; width: 30px;" class="dashicons dashicons-format-video acf-flexible-title-image"><span class="screen-reader-text">' . esc_html__( 'Video', '_s' ) . '</span></div>';
+		}
 	}
 
 	// Set default field title. Don't want to lose this.

--- a/template-parts/content-blocks/block-hero.php
+++ b/template-parts/content-blocks/block-hero.php
@@ -31,6 +31,15 @@ if ( have_rows( 'hero_slides' ) ) :
 		$button_text     = get_sub_field( 'button_text' );
 		$button_url      = get_sub_field( 'button_url' );
 		$animation_class = _s_get_animation_class();
+		$other_options   = get_sub_field( 'other_options' ) ? get_sub_field( 'other_options' ) : get_field( 'other_options' )['other_options'];
+
+		// If the block has expired, then bail!
+		if ( _s_has_block_expired( array(
+			'start_date' => $other_options['start_date'],
+			'end_date'   => $other_options['end_date'],
+		) ) ) {
+			return false;
+		}
 
 		// Start a <container> with possible block options.
 		_s_display_block_options( array(


### PR DESCRIPTION
Closes #368 

### DESCRIPTION ###
- Because there Hero block is actually a repeatable field, the "expired" check needs to happen in a sub-loop.
- Fixed PHP warning by checking for `none` as a background option first, if `none` is present, just skip everything.

### SCREENSHOTS ###

**Set the date to expire on May 2**
![screenshot](https://dl.dropbox.com/s/fauk072s8lmg29c/Screenshot%202018-05-04%2010.22.53.png?dl=0)

**Block no longer displays**
![screenshot](https://dl.dropbox.com/s/xvifutqa48ej8cr/Screenshot%202018-05-04%2010.22.29.png?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Check out this PR, and try to schedule a Hero block.

### DOCUMENTATION ###
No