### PR TITLE
Add GitLab CI Integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+image: protechig/phpcs-docker:alpine
+stages:
+  - linting
+phpcs:
+    stage: linting
+    script:
+    - find -L ./ -name '*.php' -print0 | xargs -0 -n 1 php -l
+    - ~/.composer/vendor/bin/phpcs -p -s -v -n . --standard=WebDevStudios --extensions=php -d memory_limit=256m
+    - eslint --config .eslintrc.js './assets/scripts/concat'
+    - sass-lint --config .sass-lint.yml './assets/sass/**/*.scss' --verbose --no-exit


### PR DESCRIPTION
### DESCRIPTION ###
I added support for GitLab CI to `wd_s`. I created a [Docker Image](https://hub.docker.com/r/protechig/phpcs-docker/) - [GitHub Source](https://github.com/zachary-russell/phpcs-docker) that does the following:

- Installs PHP & relevant extensions (PHP 7.2-fpm)
- Installs composer
- Installs Web Dev Studios coding standards
- Installs Node
- Installs eslint and sass-lint

The `.gitlab-ci.yml` file then just does the bare minimum it has to - 
I'm using Alpine linux to reduce binary size and get it up and running as quickly as possible. In [my tests](https://gitlab.com/protechig/test-theme/-/jobs/74187096) it takes < 1 minute to run the entire linting suite :)


### STEPS TO VERIFY ###
Launch a version of this theme on GitLab and every commit will be ran through the CI pipeline. 

### DOCUMENTATION ###
This doesn't actually need any documentation, GitLab CI will run as long as the `.gitlab-ci.yml` file is present. I'm only linting on the latest version of PHP for the time being. You _could_ set up auto syncing from GitHub to GitLab for this repo to demonstrate functionality.