### PR TITLE
Removes some default customizer fields we never use on projects

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -6,6 +6,26 @@
  */
 
 /**
+ * Removes default customizer fields that we generally don't use.
+ *
+ * @param object $wp_customize The default Customizer settings.
+ * @author Corey Collins
+ */
+function _s_remove_default_customizer_sections( $wp_customize ) {
+
+	// Remove sections.
+	$wp_customize->remove_section( 'custom_css' );
+	$wp_customize->remove_section( 'static_front_page' );
+	$wp_customize->remove_section( 'background_image' );
+	$wp_customize->remove_section( 'colors' );
+
+	// Remove panels.
+	$wp_customize->remove_panel( 'nav_menus' );
+	$wp_customize->remove_panel( 'widgets' );
+}
+add_action( 'customize_register', '_s_remove_default_customizer_sections', 15 );
+
+/**
  * Include other customizer files.
  */
 function _s_include_custom_controls() {


### PR DESCRIPTION
### DESCRIPTION ###
Removes some sections and panels from the Customizer that we generally don't use.

During training, I always run through the Customizer but always gloss over a lot of the existing/default Customizer sections with "you can do this here, but it's not the best."

I don't think I've ever known anybody to manage menus or widgets via the Customizer.

For the most part, we don't use a lot of the Customizer features or settings and having so many of them by default just creates confusion for the user. We tend to stick to Site Options and Site Identity, and I can't recall a time where we used Color, Background Image, or (gasp) Additional CSS.

Of course, these could always be added back on a per-project basis by removing the line commenting them out.

### SCREENSHOTS ###
Before:
![](https://dl.dropbox.com/s/5zgsvqaqeoawc89/Screenshot%202018-08-28%2012.32.25.jpg?dl=0)

After:
![](https://dl.dropbox.com/s/a63m1llm7xf5fl4/Screenshot%202018-08-28%2012.29.03.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Checkout the branch and open up the customizer.