### PR TITLE
#378 copyright year shortcode

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -240,23 +240,26 @@ function _s_display_customizer_footer_scripts() {
  *
  * @author Haris Zulfiqar
  * @param array $atts {.
- * @type string $starting_year Optional. Define starting year to show starting year and current year e.g. 2015 - 2018
+ * @type string $starting_year Optional. Define starting year to show starting year and current year e.g. 2015 - 2018.
  * @type string $separator Optional. Separator between starting year and current year.
  * }
  * @return string
  */
 function _s_copyright_year( $atts ) {
+
 	// Setup defaults.
 	$args = shortcode_atts( array(
 		'starting_year' => '',
 		'separator'     => ' - ',
 	), $atts );
 
+	$current_year = date( 'Y' );
+
 	// Return current year if starting year is empty.
 	if ( ! $args['starting_year'] ) {
-		return date( 'Y' );
+		return $current_year;
 	}
 
-	return $args['starting_year'] . $args['separator'] . date( 'Y' );
+	return esc_html( $args['starting_year'] . $args['separator'] . $current_year );
 }
 add_shortcode( '_s_copyright_year', '_s_copyright_year', 15 );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -233,3 +233,30 @@ function _s_display_customizer_footer_scripts() {
 	// Otherwise, echo the scripts!
 	echo force_balance_tags( $scripts ); // WPCS XSS OK.
 }
+
+
+/**
+ * Shortcode to display copyright year.
+ *
+ * @author Haris Zulfiqar
+ * @param array $atts {.
+ * @type string $starting_year Optional. Define starting year to show starting year and current year e.g. 2015 - 2018
+ * @type string $separator Optional. Separator between starting year and current year.
+ * }
+ * @return string
+ */
+function _s_copyright_year( $atts ) {
+	// Setup defaults.
+	$args = shortcode_atts( array(
+		'starting_year' => '',
+		'separator'     => ' - ',
+	), $atts );
+
+	// Return current year if starting year is empty.
+	if ( ! $args['starting_year'] ) {
+		return date( 'Y' );
+	}
+
+	return $args['starting_year'] . $args['separator'] . date( 'Y' );
+}
+add_shortcode( '_s_copyright_year', '_s_copyright_year', 15 );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -313,7 +313,7 @@ function _s_display_copyright_text() {
 	}
 
 	?>
-	<span class="copyright-text"><?php echo wp_kses_post( $copyright_text ); ?></span>
+	<span class="copyright-text"><?php echo wp_kses_post( do_shortcode( $copyright_text ) ); ?></span>
 	<?php
 }
 


### PR DESCRIPTION
Closes #378

### DESCRIPTION ###
Added a shortcode to be able to give control to the site admin for the placement of copyright year. Right now, the process is to add it within the code which can be limiting for the site admin.

Shortcode can display current year only, and starting year and current year with a customizable separator. E.g.:

[_s_copyright_year]
[_s_copyright_year starting_year="2015"] by default, separator here is " - "
[_s_copyright_year starting_year="2015" separator=" / "]

### SCREENSHOTS ###

![screen shot 2018-09-01 at 1 06 30 am](https://user-images.githubusercontent.com/601054/44933644-47b27980-ad83-11e8-9145-939c3f6c9204.png)

### OTHER ###
- [X] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [X] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [X] Does this pass CBT?

### STEPS TO VERIFY ###
From the customizer, add [_s_copyright_year] to the copyright text field.

### DOCUMENTATION ###

Yes, we should mention support for this shortcode.