### PR TITLE
Hero block: Check for button text and URL before showing button

### DIFF
--- a/template-parts/content-blocks/block-hero.php
+++ b/template-parts/content-blocks/block-hero.php
@@ -62,7 +62,7 @@ if ( have_rows( 'hero_slides' ) ) :
 				<p class="hero-description"><?php echo esc_html( $text ); ?></p>
 			<?php endif; ?>
 
-			<?php if ( $button_url ) : ?>
+			<?php if ( $button_text && $button_url ) : ?>
 				<button type="button" class="button button-hero" onclick="location.href='<?php echo esc_url( $button_url ); ?>'"><?php echo esc_html( $button_text ); ?></button>
 			<?php endif; ?>
 


### PR DESCRIPTION
Closes #383 

### DESCRIPTION ###

Simply added a check in code to make sure both button text and URL exists in hero block before showing the button.

### SCREENSHOTS ###

<img width="871" alt="screen shot 2018-09-07 at 4 45 04 am" src="https://user-images.githubusercontent.com/601054/45190719-e1cd6280-b258-11e8-97bb-c4a79bcaf5d7.png">
<img width="486" alt="screen shot 2018-09-07 at 4 45 10 am" src="https://user-images.githubusercontent.com/601054/45190746-fe699a80-b258-11e8-9333-c8c7c6d294ad.png">
<img width="585" alt="screen shot 2018-09-07 at 4 45 16 am" src="https://user-images.githubusercontent.com/601054/45190747-fe699a80-b258-11e8-8b9c-349db6aca56e.png">
<img width="502" alt="screen shot 2018-09-07 at 4 45 19 am" src="https://user-images.githubusercontent.com/601054/45190748-ff023100-b258-11e8-9967-5486f28bb3c0.png">

### OTHER ###
- [X] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [X] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [X] Does this pass CBT?

### STEPS TO VERIFY ###

Create hero slides with button text only, with button url only and with button text and url.

### DOCUMENTATION ###

No documentation update needed