### PR TITLE
Adds filters to search post meta using default WP search

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -152,6 +152,11 @@ require get_template_directory() . '/inc/scripts.php';
 require get_template_directory() . '/inc/acf.php';
 
 /**
+ * Load custom ACF search functionality.
+ */
+require get_template_directory() . '/inc/acf-search.php';
+
+/**
  * Load custom filters and hooks.
  */
 require get_template_directory() . '/inc/hooks.php';

--- a/inc/acf-search.php
+++ b/inc/acf-search.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * ACF/Post Meta Search.
+ *
+ * Extend WordPress search to include custom fields.
+ * https://adambalee.com
+ *
+ * @package _s
+ */
+
+/**
+ * Join posts and postmeta tables
+ * http://codex.wordpress.org/Plugin_API/Filter_Reference/posts_join
+ *
+ * @param string $join The SQL query.
+ * @return $join The updated query.
+ * @author Corey Collins
+ */
+function _s_search_join( $join ) {
+	global $wpdb;
+
+	if ( is_search() ) {
+		$join .= ' LEFT JOIN ' . $wpdb->postmeta . ' ON ' . $wpdb->posts . '.ID = ' . $wpdb->postmeta . '.post_id ';
+	}
+
+	return $join;
+}
+add_filter( 'posts_join', '_s_search_join' );
+
+/**
+ * Modify the search query with posts_where.
+ * http://codex.wordpress.org/Plugin_API/Filter_Reference/posts_where
+ *
+ * @param string $where The SQL query.
+ * @return $where The updated query.
+ * @author Corey Collins
+ */
+function _s_search_where( $where ) {
+	global $pagenow, $wpdb;
+
+	if ( is_search() ) {
+		$where = preg_replace(
+			'/\(\s*' . $wpdb->posts . '.post_title\s+LIKE\s*(\'[^\']+\')\s*\)/',
+			'(' . $wpdb->posts . '.post_title LIKE $1) OR (' . $wpdb->postmeta . '.meta_value LIKE $1)',
+			$where
+		);
+	}
+
+	return $where;
+}
+add_filter( 'posts_where', '_s_search_where' );
+
+/**
+ * Prevent duplicates.
+ * http://codex.wordpress.org/Plugin_API/Filter_Reference/posts_distinct
+ *
+ * @param string $where The SQL query.
+ * @return $where The updated query.
+ * @author Corey Collins
+ */
+function _s_search_distinct( $where ) {
+	global $wpdb;
+
+	if ( is_search() ) {
+		return 'DISTINCT';
+	}
+
+	return $where;
+}
+add_filter( 'posts_distinct', '_s_search_distinct' );


### PR DESCRIPTION
### DESCRIPTION ###
This adds a few filters to allow our ACF fields (and really, all meta fields) to be found in a basic WordPress search. Since so many pages can be driven by ACF content, we need to make sure that content is searchable by users otherwise it will simply not be surfaced without an additional search plugin to extend search.

@kellenmace and I came across this blog post which he reviewed from a BEE perspective and did not see any security issues or other risks in using: https://adambalee.com/search-wordpress-by-custom-fields-without-a-plugin/

I've added this as its own includes file rather than adding it to our main `acf.php` file since it adds its own hefty functionality specific to search. This makes it easy to remove quickly if we need to for some reason.

### SCREENSHOTS ###
I added a string of `onlyfoundinmeta` to a content block on my local:
![](https://dl.dropbox.com/s/x7n42xhuz86iff5/Screenshot%202018-09-21%2010.38.18.jpg?dl=0)

Searching by default yields no results:
![](https://dl.dropbox.com/s/k71jemikbuzgonp/Screenshot%202018-09-21%2010.37.48.jpg?dl=0)

Searching with this code in place yields the page as a result:
![](https://dl.dropbox.com/s/31sngpzxgssww82/Screenshot%202018-09-21%2010.37.56.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Checkout the branch and add some content to your ACF blocks. Search for that content and rejoice! Comment out the `require` in `functions.php` if you want to test a before & after.

### DOCUMENTATION ###
I don't think so. This doesn't change how we work at all, just adds some behind-the-scenes functionality but I'm happy to add some notes around this if we feel it's needed.