### PR TITLE
Replaces the <button> with an <input> to submit search results form

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -10,5 +10,5 @@
 <form method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="search-field"><span class="screen-reader-text"><?php esc_html_e( 'To search this site, enter a search term', '_s' ); ?></span></label>
 	<input class="search-field" id="search-field" type="text" name="s" value="<?php echo get_search_query(); ?>" aria-required="false" autocomplete="off" placeholder="<?php echo esc_attr_x( 'Search', '_s' ); ?>" />
-	<button type="button" class="button button-search"><?php esc_html_e( 'Submit', '_s' ); ?></button>
+	<input type="submit" id="searchsubmit" class="button button-search" value="<?php echo esc_attr( 'Submit', '_s' ); ?>" />
 </form>

--- a/searchform.php
+++ b/searchform.php
@@ -9,6 +9,6 @@
 
 <form method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="search-field"><span class="screen-reader-text"><?php esc_html_e( 'To search this site, enter a search term', '_s' ); ?></span></label>
-	<input class="search-field" id="search-field" type="text" name="s" value="<?php echo get_search_query(); ?>" aria-required="false" autocomplete="off" placeholder="<?php echo esc_attr_x( 'Search', '_s' ); ?>" />
-	<input type="submit" id="search-submit" class="button button-search" value="<?php echo esc_attr( 'Submit', '_s' ); ?>" />
+	<input class="search-field" id="search-field" type="text" name="s" value="<?php echo get_search_query(); ?>" aria-required="false" autocomplete="off" placeholder="<?php echo esc_attr_e( 'Search', '_s' ); ?>" />
+	<input type="submit" id="search-submit" class="button button-search" value="<?php esc_attr_e( 'Submit', '_s' ); ?>" />
 </form>

--- a/searchform.php
+++ b/searchform.php
@@ -10,5 +10,5 @@
 <form method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="search-field"><span class="screen-reader-text"><?php esc_html_e( 'To search this site, enter a search term', '_s' ); ?></span></label>
 	<input class="search-field" id="search-field" type="text" name="s" value="<?php echo get_search_query(); ?>" aria-required="false" autocomplete="off" placeholder="<?php echo esc_attr_x( 'Search', '_s' ); ?>" />
-	<input type="submit" id="searchsubmit" class="button button-search" value="<?php echo esc_attr( 'Submit', '_s' ); ?>" />
+	<input type="submit" id="search-submit" class="button button-search" value="<?php echo esc_attr( 'Submit', '_s' ); ?>" />
 </form>


### PR DESCRIPTION
Closes #394 

### DESCRIPTION ###
Relpaces the `<button>` in `searchform.php` with an `<input>` to submit the search form.

### SCREENSHOTS ###
![](https://dl.dropbox.com/s/r0lhlpsbzy898xz/Screenshot%202018-09-21%2010.56.28.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Open the search in the header or visit the 404 page. On `master`, pressing the Submit button won't trigger a search. On this branch, with the button replaced with a submit input, the button will trigger the search.
