### PR TITLE
Theme/#397 og meta tags

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -153,7 +153,7 @@ function _s_add_og_tags() {
 	$post_content = $post ? $post->post_content : '';
 
 	// Strip all tags from the post content we just grabbed.
-	$default_content = wp_strip_all_tags( $post_content );
+	$default_content = wp_strip_all_tags( strip_shortcodes( $post_content ) );
 
 	// Set our default title.
 	$default_title = get_bloginfo( 'name' );

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -211,7 +211,7 @@ function _s_add_og_tags() {
 		$card_type      = 'website';
 
 		// Translators: get the term name.
-		$long_description = $card_description = sprintf( esc_html__( 'Posts %1$s %2$s.', '_s' ), $specify, $term_name );
+		$card_long_description = $card_description = sprintf( esc_html__( 'Posts %1$s %2$s.', '_s' ), $specify, $term_name );
 	}
 
 	// Search results.
@@ -223,7 +223,7 @@ function _s_add_og_tags() {
 		$card_type   = 'website';
 
 		// Translators: get the search term.
-		$long_description = $card_description = sprintf( esc_html__( 'Search results for %s.', '_s' ), $search_term );
+		$card_long_description = $card_description = sprintf( esc_html__( 'Search results for %s.', '_s' ), $search_term );
 	}
 
 	if ( is_home() ) {

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -254,9 +254,8 @@ function _s_add_og_tags() {
 
 	// Media page.
 	if ( is_attachment() ) {
-		$attachment_id        = get_the_ID();
-		$attachment_image_url = ( wp_attachment_is_image( $attachment_id ) ) ? wp_get_attachment_image_url( $attachment_id, 'full' ) : $card_image;
-		$card_image           = $attachment_image_url;
+		$attachment_id  = get_the_ID();
+		$card_image     = ( wp_attachment_is_image( $attachment_id ) ) ? wp_get_attachment_image_url( $attachment_id, 'full' ) : $card_image;
 	}
 
 	?>

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -162,7 +162,7 @@ function _s_add_og_tags() {
 	$default_url = get_permalink();
 
 	// Set our base description.
-	$default_base_description = get_bloginfo( 'description' ) ? get_bloginfo( 'description' ) : __( 'Visit our website to learn more.', '_s' );
+	$default_base_description = get_bloginfo( 'description' ) ? get_bloginfo( 'description' ) : esc_html( 'Visit our website to learn more.', '_s' );
 
 	// Set the card type.
 	$default_type = 'article';
@@ -202,13 +202,13 @@ function _s_add_og_tags() {
 
 		$term_name      = single_term_title( '', false );
 		$card_title     = $term_name . ' - ' . $default_title;
-		$specify        = is_category() ? __( 'categorized in', '_s' ) : __( 'tagged with', '_s' );
+		$specify        = is_category() ? esc_html( 'categorized in', '_s' ) : esc_html( 'tagged with', '_s' );
 		$queried_object = get_queried_object();
 		$card_url       = get_term_link( $queried_object );
 		$card_type      = 'website';
 
 		// Translators: get the term name.
-		$long_description = $card_description = sprintf( __( 'Posts %1$s %2$s.', '_s' ), $specify, $term_name );
+		$long_description = $card_description = sprintf( esc_html( 'Posts %1$s %2$s.', '_s' ), $specify, $term_name );
 	}
 
 	// Search results.
@@ -220,7 +220,7 @@ function _s_add_og_tags() {
 		$card_type   = 'website';
 
 		// Translators: get the search term.
-		$long_description = $card_description = sprintf( __( 'Search results for %s.', '_s' ), $search_term );
+		$long_description = $card_description = sprintf( esc_html( 'Search results for %s.', '_s' ), $search_term );
 	}
 
 	if ( is_home() ) {

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -252,6 +252,13 @@ function _s_add_og_tags() {
 		$card_type      = 'website';
 	}
 
+	// Media page.
+	if ( is_attachment() ) {
+		$attachment_id        = get_the_ID();
+		$attachment_image_url = ( wp_attachment_is_image( $attachment_id ) ) ? wp_get_attachment_image_url( $attachment_id, 'full' ) : $card_image;
+		$card_image           = $attachment_image_url;
+	}
+
 	?>
 	<meta property="og:title" content="<?php echo esc_attr( $card_title ); ?>" />
 	<meta property="og:description" content="<?php echo esc_attr( $card_description ); ?>" />

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -150,10 +150,10 @@ function _s_add_og_tags() {
 	global $post;
 
 	// Get the post content.
-	$post_content = $post ? $post->post_content : '';
+	$post_content = ( $post ) ? $post->post_content : '';
 
 	// Strip all tags from the post content we just grabbed.
-	$default_content = $post_content ? wp_strip_all_tags( strip_shortcodes( $post_content ) ) : $post_content;
+	$default_content = ( $post_content ) ? wp_strip_all_tags( strip_shortcodes( $post_content ) ) : $post_content;
 
 	// Set our default title.
 	$default_title = get_bloginfo( 'name' );
@@ -162,15 +162,15 @@ function _s_add_og_tags() {
 	$default_url = get_permalink();
 
 	// Set our base description.
-	$default_base_description = get_bloginfo( 'description' ) ? get_bloginfo( 'description' ) : esc_html( 'Visit our website to learn more.', '_s' );
+	$default_base_description = ( get_bloginfo( 'description' ) ) ? get_bloginfo( 'description' ) : esc_html( 'Visit our website to learn more.', '_s' );
 
 	// Set the card type.
 	$default_type = 'article';
 
 	// Get our custom logo URL. We'll use this on archives and when no featured image is found.
 	$logo_id    = get_theme_mod( 'custom_logo' );
-	$logo_image = $logo_id ? wp_get_attachment_image_src( $logo_id, 'full' ) : '';
-	$logo_url   = $logo_id ? $logo_image[0] : '';
+	$logo_image = ( $logo_id ) ? wp_get_attachment_image_src( $logo_id, 'full' ) : '';
+	$logo_url   = ( $logo_id ) ? $logo_image[0] : '';
 
 	// Set our final defaults.
 	$card_title            = $default_title;
@@ -193,8 +193,8 @@ function _s_add_og_tags() {
 	if ( is_singular() && ! is_front_page() ) {
 
 		$card_title            = get_the_title() . ' - ' . $default_title;
-		$card_description      = $default_content ? wp_trim_words( $default_content, 53, '...' ) : $default_base_description;
-		$card_long_description = $default_content ? wp_trim_words( $default_content, 140, '...' ) : $default_base_description;
+		$card_description      = ( $default_content ) ? wp_trim_words( $default_content, 53, '...' ) : $default_base_description;
+		$card_long_description = ( $default_content ) ? wp_trim_words( $default_content, 140, '...' ) : $default_base_description;
 	}
 
 	// Categories, Tags, and Custom Taxonomies.
@@ -202,7 +202,7 @@ function _s_add_og_tags() {
 
 		$term_name      = single_term_title( '', false );
 		$card_title     = $term_name . ' - ' . $default_title;
-		$specify        = is_category() ? esc_html( 'categorized in', '_s' ) : esc_html( 'tagged with', '_s' );
+		$specify        = ( is_category() ) ? esc_html( 'categorized in', '_s' ) : esc_html( 'tagged with', '_s' );
 		$queried_object = get_queried_object();
 		$card_url       = get_term_link( $queried_object );
 		$card_type      = 'website';
@@ -235,7 +235,7 @@ function _s_add_og_tags() {
 	if ( is_front_page() ) {
 
 		$front_page = get_option( 'page_on_front' );
-		$card_title = $front_page ? get_the_title( $front_page ) . ' - ' . $default_title : $default_title;
+		$card_title = ( $front_page ) ? get_the_title( $front_page ) . ' - ' . $default_title : $default_title;
 		$card_url   = get_home_url();
 		$card_type  = 'website';
 	}

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -153,7 +153,7 @@ function _s_add_og_tags() {
 	$post_content = $post ? $post->post_content : '';
 
 	// Strip all tags from the post content we just grabbed.
-	$default_content = wp_strip_all_tags( strip_shortcodes( $post_content ) );
+	$default_content = $post_content ? wp_strip_all_tags( strip_shortcodes( $post_content ) ) : $post_content;
 
 	// Set our default title.
 	$default_title = get_bloginfo( 'name' );

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -147,10 +147,13 @@ function _s_add_og_tags() {
 		return '';
 	}
 
-	global $post;
+	// Set a post global on single posts. This avoids grabbing content from the first post on an archive page.
+	if ( is_singular() ) {
+		global $post;
+	}
 
 	// Get the post content.
-	$post_content = ( $post ) ? $post->post_content : '';
+	$post_content = ! empty( $post ) ? $post->post_content : '';
 
 	// Strip all tags from the post content we just grabbed.
 	$default_content = ( $post_content ) ? wp_strip_all_tags( strip_shortcodes( $post_content ) ) : $post_content;

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -162,7 +162,7 @@ function _s_add_og_tags() {
 	$default_url = get_permalink();
 
 	// Set our base description.
-	$default_base_description = ( get_bloginfo( 'description' ) ) ? get_bloginfo( 'description' ) : esc_html( 'Visit our website to learn more.', '_s' );
+	$default_base_description = ( get_bloginfo( 'description' ) ) ? get_bloginfo( 'description' ) : esc_html__( 'Visit our website to learn more.', '_s' );
 
 	// Set the card type.
 	$default_type = 'article';
@@ -202,13 +202,13 @@ function _s_add_og_tags() {
 
 		$term_name      = single_term_title( '', false );
 		$card_title     = $term_name . ' - ' . $default_title;
-		$specify        = ( is_category() ) ? esc_html( 'categorized in', '_s' ) : esc_html( 'tagged with', '_s' );
+		$specify        = ( is_category() ) ? esc_html__( 'categorized in', '_s' ) : esc_html__( 'tagged with', '_s' );
 		$queried_object = get_queried_object();
 		$card_url       = get_term_link( $queried_object );
 		$card_type      = 'website';
 
 		// Translators: get the term name.
-		$long_description = $card_description = sprintf( esc_html( 'Posts %1$s %2$s.', '_s' ), $specify, $term_name );
+		$long_description = $card_description = sprintf( esc_html__( 'Posts %1$s %2$s.', '_s' ), $specify, $term_name );
 	}
 
 	// Search results.
@@ -220,7 +220,7 @@ function _s_add_og_tags() {
 		$card_type   = 'website';
 
 		// Translators: get the search term.
-		$long_description = $card_description = sprintf( esc_html( 'Search results for %s.', '_s' ), $search_term );
+		$long_description = $card_description = sprintf( esc_html__( 'Search results for %s.', '_s' ), $search_term );
 	}
 
 	if ( is_home() ) {

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -223,10 +223,19 @@ function _s_add_og_tags() {
 		$long_description = $card_description = sprintf( __( 'Search results for %s.', '_s' ), $search_term );
 	}
 
+	if ( is_home() ) {
+
+		$posts_page = get_option( 'page_for_posts' );
+		$card_title = get_the_title( $posts_page ) . ' - ' . $default_title;
+		$card_url   = get_permalink( $posts_page );
+		$card_type  = 'website';
+	}
+
 	// Front page.
 	if ( is_front_page() ) {
 
-		$card_title = $default_title;
+		$front_page = get_option( 'page_on_front' );
+		$card_title = $front_page ? get_the_title( $front_page ) . ' - ' . $default_title : $default_title;
 		$card_url   = get_home_url();
 		$card_type  = 'website';
 	}


### PR DESCRIPTION
Closes #397 

### DESCRIPTION ###
Added default OG tags, and a meta description tag, for sites who don't use Yoast to power social sharing cards.

First, we check to see if the `WPSEO_Options` class exists. If it does, Yoast is active so we bail as to not interfere with Yoast's setup.

This works as such:
First, we try to find our default card content which is:
- Post content
- Post title
- Post permalink
- Base description, which is either the provided site description in settings or a basic string
- Article type, which defaults to `article`

Additionally, we grab the following for potential use later:
- Logo from the Customizer which we set as the default image

If we're on a single post we:
- Replace the default image with the featured image, if one exists

if we're on a single post which isn't the front page we:
- Append the site name to the post title for the card title
- Trim the post content for long and short cards

If we're on a category, tag, or custom taxonomy we:
- Append the site name to the term name for the card title
- Set the card description to be either `categorized in` or `tagged with` based on whether or not the term is explicitly a category
- Set the card URL to the term link URL
- Set the card type to `website`

If we're on search results we:
- Append the site name to the search query for the card title
- Set the card URL to the search results URL
- Set the card type to `website`
- Set a basic description for the search results for long and short descriptions

If we're on the home page we:
- Get the title of the `page_for_posts` and append the site title for the card title
- Get the permalink of the posts page for the card URL
- Set the card type to `website`

If we're on the front page we:
- Get the title of the `page_on_front` and append the site title for the card title
- Get the `home_url()` for the card URL
- Set the card type to `website`

If we're on a post type archive we:
- Append the site name to the post type name for the card title
- Set the post type archive URL as the card URL
- Set the card type to `website`

### SCREENSHOTS ###
Homepage tags:
![](https://dl.dropbox.com/s/zulo9dt9cz8o9ak/Screenshot%202018-09-27%2010.12.29.jpg?dl=0)

Blog page tags:
![](https://dl.dropbox.com/s/6h5z0cjpht5ust3/Screenshot%202018-09-27%2010.13.07.jpg?dl=0)

Category tags:
![](https://dl.dropbox.com/s/zfbys8boo57g63h/Screenshot%202018-09-27%2010.13.39.jpg?dl=0)

Tag tags:
![](https://dl.dropbox.com/s/qfikprs54es7gby/Screenshot%202018-09-27%2010.14.03.jpg?dl=0)

Single post tags:
![](https://dl.dropbox.com/s/x01tui1t6s1hmf6/Screenshot%202018-09-27%2010.16.04.jpg?dl=0)

Search results tags:
![](https://dl.dropbox.com/s/abfum44add46i8l/Screenshot%202018-09-27%2010.16.37.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Check out the branch and poke around various pages, viewing the source and looking at the tags.

### DOCUMENTATION ###
I don't think so? It should just be there and work (:crossed:), and not fall into place if Yoast is active, so I don't think we need to? But maybe. I could be under-thinking it since I'm familiar with it myself.