### PR TITLE
Hotfix/#399 attribute spacing

### DIFF
--- a/inc/acf.php
+++ b/inc/acf.php
@@ -76,7 +76,7 @@ function _s_display_block_options( $args = array() ) {
 	if ( $args['background_type'] ) {
 		if ( 'color' === $args['background_type'] ) {
 			$background_color = $background_options['background_color'];
-			$inline_style    .= 'background-color: ' . $background_color . '; ';
+			$inline_style    .= 'background-color: ' . $background_color . ';';
 			$args['class']   .= ' has-background color-as-background';
 		}
 
@@ -112,7 +112,7 @@ function _s_display_block_options( $args = array() ) {
 
 	// Set the custom font color.
 	if ( $args['font_color'] ) {
-		$inline_style .= 'color: ' . $args['font_color'] . '; ';
+		$inline_style .= 'color: ' . $args['font_color'] . ';';
 	}
 
 	// Set the custom ID.

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -160,7 +160,7 @@ function _s_get_animation_class() {
 
 	// If we have an animation set...
 	if ( $other_options['animation'] ) {
-		$classes = 'animated ' . $other_options['animation'];
+		$classes = ' animated ' . $other_options['animation'];
 	}
 
 	return $classes;

--- a/template-parts/content-blocks/block-cta.php
+++ b/template-parts/content-blocks/block-cta.php
@@ -20,7 +20,7 @@ _s_display_block_options(
 	)
 );
 ?>
-	<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
+	<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
 		<div class="cell">
 			<?php if ( $title ) : ?>
 				<h3 class="cta-title"><?php echo esc_html( $title ); ?></h3>

--- a/template-parts/content-blocks/block-fifty_media_text.php
+++ b/template-parts/content-blocks/block-fifty_media_text.php
@@ -16,7 +16,7 @@ _s_display_block_options( array(
 	'class'     => 'content-block grid-container fifty-fifty fifty-media-text', // The class of the container.
 ) );
 ?>
-	<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
+	<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
 
 		<div class="cell">
 			<img class="fifty-image" src="<?php echo esc_url( $image_data['url'] ); ?>" alt="<?php echo esc_html( $image_data['alt'] ); ?>">

--- a/template-parts/content-blocks/block-fifty_text_media.php
+++ b/template-parts/content-blocks/block-fifty_text_media.php
@@ -16,7 +16,7 @@ _s_display_block_options( array(
 	'class'     => 'content-block grid-container fifty-fifty fifty-text-media', // Container class.
 ) );
 ?>
-	<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
+	<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
 
 		<div class="cell">
 			<?php

--- a/template-parts/content-blocks/block-fifty_text_only.php
+++ b/template-parts/content-blocks/block-fifty_text_only.php
@@ -16,7 +16,7 @@ _s_display_block_options( array(
 	'class'     => 'content-block grid-container fifty-fifty fifty-text-only', // The container class.
 ) );
 ?>
-	<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
+	<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
 
 		<div class="cell">
 			<?php

--- a/template-parts/content-blocks/block-generic_content.php
+++ b/template-parts/content-blocks/block-generic_content.php
@@ -18,7 +18,7 @@ _s_display_block_options(
 	)
 );
 ?>
-	<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
+	<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
 
 		<?php if ( $title ) : ?>
 			<h2 class="generic-content-title"><?php echo esc_html( $title ); ?></h2>

--- a/template-parts/content-blocks/block-hero.php
+++ b/template-parts/content-blocks/block-hero.php
@@ -20,7 +20,7 @@ _s_display_block_options(
 	)
 );
 ?>
-	<div class="hero-content <?php echo esc_attr( $animation_class ); ?>">
+	<div class="hero-content<?php echo esc_attr( $animation_class ); ?>">
 		<?php if ( $title ) : ?>
 			<h2 class="hero-title"><?php echo esc_html( $title ); ?></h2>
 		<?php endif; ?>

--- a/template-parts/content-blocks/block-recent_posts.php
+++ b/template-parts/content-blocks/block-recent_posts.php
@@ -48,7 +48,7 @@ if ( $recent_posts->have_posts() ) :
 	<?php endif; ?>
 	</div>
 
-	<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
+	<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
 
 		<?php
 		// Loop through recent posts.

--- a/template-parts/content-blocks/block-related_posts.php
+++ b/template-parts/content-blocks/block-related_posts.php
@@ -29,7 +29,7 @@ if ( $related_posts ) :
 	<?php endif; ?>
 	</div>
 
-	<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
+	<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
 
 		<?php
 		// Loop through recent posts.


### PR DESCRIPTION
Closes #399

### DESCRIPTION ###
Updates our inline styles and animated class setups on content blocks to avoid having an empty space at the end of an attribute.

Before:
```
<div class="grid-x <?php echo esc_attr( $animation_class ); ?>">
$classes = 'animated ' . $other_options['animation'];
```

Because of the above, if a block has no animation set then the `div` ends up with an empty space at the end.

After:
```
<div class="grid-x<?php echo esc_attr( $animation_class ); ?>">
$classes = ' animated ' . $other_options['animation'];
```

With the adjustment, there is no extra space if there is no animation set. Additionally, the space is added in the class variable itself to ensure there is a space when the classes are added.

I've also updated our inline styles to remove extra spaces after the closing semicolons, since we don't need to worry about them looking super pretty as inline styles (and I might have another PR around those all together next 5FTF) and leaving them in causes an empty space at the end of the attribute.

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Add blocks with and without background elements (image, color, video) and animations.