### PR TITLE
Replaces return with continue in expiration check

### DIFF
--- a/inc/acf.php
+++ b/inc/acf.php
@@ -14,8 +14,6 @@ if ( ! class_exists( 'acf' ) ) {
 
 /**
  * Loop through and output ACF flexible content blocks for the current page.
- *
- * @return bool
  */
 function _s_display_content_blocks() {
 	if ( have_rows( 'content_blocks' ) ) :

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -30,7 +30,7 @@ function _s_display_content_blocks() {
 				'start_date' => $other_options['start_date'],
 				'end_date'   => $other_options['end_date'],
 			) ) ) {
-				return false;
+				continue;
 			}
 
 			get_template_part( 'template-parts/content-blocks/block', get_row_layout() ); // Template part name MUST match layout ID.


### PR DESCRIPTION
Closes #403 

### DESCRIPTION ###
Replaced `return false` with `continue` to avoid all blocks following an expired block from also being "hidden" due an inaccurate expiration value.

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Add a set of blocks where one has an expiration date. There must be blocks in place _after_ this block. On `master`, all blocks after and including the expired block will not display.

Then, checkout this branch and refresh the page. Now, the expired block should not be displayed while the other blocks are.