### PR TITLE
Theme/menu refinements

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -24,25 +24,7 @@
 
 <?php wp_footer(); ?>
 
-<nav class="off-canvas-container" aria-hidden="true">
-	<button type="button" class="off-canvas-close" aria-label="<?php esc_html_e( 'Close Menu', '_s' ); ?>">
-		<span class="close"></span>
-	</button>
-	<?php
-		// Mobile menu args.
-		$mobile_args = array(
-			'theme_location'  => 'mobile',
-			'container'       => 'div',
-			'container_class' => 'off-canvas-content',
-			'container_id'    => '',
-			'menu_id'         => 'mobile-menu',
-			'menu_class'      => 'mobile-menu',
-		);
+<?php _s_display_mobile_menu(); ?>
 
-		// Display the mobile menu.
-		wp_nav_menu( $mobile_args );
-	?>
-</nav>
-<div class="off-canvas-screen"></div>
 </body>
 </html>

--- a/header.php
+++ b/header.php
@@ -48,20 +48,23 @@
 
 		<?php _s_display_header_button(); ?>
 
-		<button type="button" class="off-canvas-open" aria-expanded="false" aria-label="<?php esc_html_e( 'Open Menu', '_s' ); ?>">
-			<span class="hamburger"></span>
-		</button>
+		<?php if ( has_nav_menu( 'primary' ) || has_nav_menu( 'mobile' ) ) : ?>
+			<button type="button" class="off-canvas-open" aria-expanded="false" aria-label="<?php esc_html_e( 'Open Menu', '_s' ); ?>">
+				<span class="hamburger"></span>
+			</button>
+		<?php endif; ?>
 
-		<nav id="site-navigation" class="main-navigation">
-			<?php
-				wp_nav_menu( array(
-					'theme_location' => 'primary',
-					'menu_id'        => 'primary-menu',
-					'menu_class'     => 'menu dropdown',
-				) );
-			?>
-		</nav><!-- #site-navigation -->
-
+		<?php
+		wp_nav_menu( array(
+			'fallback_cb'     => false,
+			'theme_location'  => 'primary',
+			'menu_id'         => 'primary-menu',
+			'menu_class'      => 'menu dropdown',
+			'container'       => 'nav',
+			'container_class' => 'main-navigation',
+			'container_id'    => 'site-navigation',
+		) );
+		?>
 	</header><!-- .site-header-->
 
 	<div id="content" class="site-content">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -478,3 +478,48 @@ function _s_display_header_button() {
 	</div><!-- .header-trigger -->
 	<?php
 }
+
+/**
+ * Displays the mobile menu with off-canvas background layer.
+ *
+ * @return string An empty string if no menus are found at all.
+ * @author Corey Collins
+ */
+function _s_display_mobile_menu() {
+
+	// Bail if no mobile or primary menus are set.
+	if ( ! has_nav_menu( 'mobile' ) && ! has_nav_menu( 'primary' ) ) {
+		return '';
+	}
+
+	// Set a default menu location.
+	$menu_location = 'primary';
+
+	// If we have a mobile menu explicitly set, use it.
+	if ( has_nav_menu( 'mobile' ) ) {
+		$menu_location = 'mobile';
+	}
+	?>
+	<div class="off-canvas-screen"></div>
+	<nav class="off-canvas-container" aria-hidden="true">
+		<button type="button" class="off-canvas-close" aria-label="<?php esc_html_e( 'Close Menu', '_s' ); ?>">
+			<span class="close"></span>
+		</button>
+		<?php
+		// Mobile menu args.
+		$mobile_args = array(
+			'theme_location'  => $menu_location,
+			'container'       => 'div',
+			'container_class' => 'off-canvas-content',
+			'container_id'    => '',
+			'menu_id'         => 'site-mobile-menu',
+			'menu_class'      => 'mobile-menu',
+			'fallback_cb'     => false,
+		);
+
+		// Display the mobile menu.
+		wp_nav_menu( $mobile_args );
+		?>
+	</nav>
+	<?php
+}


### PR DESCRIPTION
### DESCRIPTION ###
This cleans up some of our logic and functionality around how are menus work and display.

**The Before Times**
Our menus would work like this...
1. The burger menu button would always display, regardless if whether a proper Primary or Mobile menu were set. Not good 👎 
2. The primary menu would do the default WP thing of grabbing all of the top level pages and dumping them into the menu if no Primary menu was set. I don't think anyone has ever wanted this to be a thing.  To add to this, the menu would not be visible on the screen but still read by the screen reader. Not good 👎 
3. The primary menu was wrapped in a `nav` container, but we can accomplish this through regular `wp_nav_menu` args. Not good 👎 
4. The mobile menu worked much in the same was as 1 & 2, where if no mobile menu was explicitly set, every page is displayed in the menu. Not good 👎 

**The After Times**
1. The burger icon only displays if either the mobile or primary menus are set. Good 👍 
2. The primary menu has `fallback_cb` set to `false` so it won't try to pull in all of the pages if no menu is set. Good 👍 
3. The explicit `nav` markup is removed in favor of setting the container attributes in `wp_nav_menu`. Good 👍 
4. The mobile menu has `fallback_cb` set to `false` so it won't try to pull in all of the pages if no menu is set. Good 👍 
5. The mobile menu and overlay will not display if no primary or mobile menu are set. Good 👍 
6. The mobile menu will default to using the primary menu, but will use the mobile menu if a menu is set for that location. Good 👍 
7. Changed the ID of the mobile menu from `mobile-menu` to `site-mobile-menu` to differentiate it from the menu class, which is also `mobile-menu`. There did not seem to be any references to the ID `mobile-menu` in the theme, just the class. Good 👍 

### SCREENSHOTS ###
The only screenshot that really makes anything different is that, if no Primary or Mobile menus are set, there is no burger icon:
![](https://dl.dropbox.com/s/ewhgco55skfvcev/Screenshot%202018-10-08%2010.45.25.jpg?dl=0)

Otherwise, everything should remain business as usual.

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Checkout the branch and test:
1. With only a primary menu set
2. With only a mobile menu set
3. With both primary and mobile menu set
4. With neither primary or mobile menu set

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

Yes – if accepted, updating the `Template Tags` section with reference to the new `_s_display_mobile_menu()` template tag.