### PR TITLE
Corrected link to translating WP theme, link has moved

### DIFF
--- a/languages/readme.txt
+++ b/languages/readme.txt
@@ -2,5 +2,5 @@ Place your theme language files in this directory.
 
 Please visit the following links to learn more about translating WordPress themes:
 
-http://codex.wordpress.org/Translating_WordPress
+https://make.wordpress.org/polyglots/handbook/
 http://codex.wordpress.org/Function_Reference/load_theme_textdomain


### PR DESCRIPTION
Closes #347 #436  

### DESCRIPTION ###
I edited the readme.txt in the languages folder to reflect the recent changes in Wordpress codex. The page is now located on https://make.wordpress.org/polyglots/handbook/

### SCREENSHOTS ###
No screenshot

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
How do we test this? Just check out the old links and see if they're still relevant. 

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)? Perhaps, if the same internet link is used in the wiki. 