### PR TITLE
Adds unique identifiers to form labels and inputs

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -5,12 +5,14 @@
  * @package _s
  */
 
+// Make sure our search forms have unique IDs in the event more than 1 is on a page.
+$random_identifier = wp_rand();
 ?>
 
 <form method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-	<label for="search-field">
+	<label for="search-field-<?php echo esc_attr( $random_identifier ); ?>">
 		<span class="screen-reader-text"><?php esc_html_e( 'To search this site, enter a search term', '_s' ); ?></span>
-		<input class="search-field" id="search-field" type="text" name="s" value="<?php echo get_search_query(); ?>" aria-required="false" autocomplete="off" placeholder="<?php echo esc_attr_e( 'Search', '_s' ); ?>" />
+		<input class="search-field" id="search-field-<?php echo esc_attr( $random_identifier ); ?>" type="text" name="s" value="<?php echo get_search_query(); ?>" aria-required="false" autocomplete="off" placeholder="<?php echo esc_attr_e( 'Search', '_s' ); ?>" />
 	</label>
 	<input type="submit" id="search-submit" class="button button-search" tabindex="-1" value="<?php esc_attr_e( 'Submit', '_s' ); ?>" />
 </form>


### PR DESCRIPTION
Closes #486

### DESCRIPTION ###
Adds a unique identifier to each instance of `searchform.php` so we avoid having duplicate IDs on pages where multiple search forms are found (i.e., when a search form is in the header and we are on 404 pages or pages with search forms in the sidebar).

There are no visual changes on the frontend, and the form classes remain the same.

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Checkout the branch and hit a 404 page. Run an a11y test (WAVE, pa11y, etc) and see that the duplicate label/ID issue is not present. Compare to the same page when `master` is checked out.
