### PR TITLE
Adds a default icon for the Accordion block

### DIFF
--- a/inc/acf-gutenberg.php
+++ b/inc/acf-gutenberg.php
@@ -32,6 +32,7 @@ function _s_acf_init() {
 			'description'     => esc_html__( 'A custom set of collapsable accordion items.', '_s' ),
 			'render_callback' => '_s_acf_block_registration_callback',
 			'category'        => 'wds-blocks',
+			'icon'            => 'sort',
 			'keywords'        => array( 'accordion', 'wds' ),
 			'mode'            => 'preview',
 			'enqueue_assets'  => '_s_acf_enqueue_accordion_scripts',


### PR DESCRIPTION
Closes #492

### DESCRIPTION ###
Adds a default icon to fix a breaking problem in WP 5.3.

### SCREENSHOTS ###
![](https://dl.dropbox.com/s/i0x0l9atgntnd28/Screenshot%202019-10-04%2008.28.33.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Use [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) to install the latest nightly version of WP and test wd_s in `master` and on this branch. On `master`, things break when trying to add blocks because the Carousel block had no icon set. Previously this was fine because WP would just default to the default icon. In 5.3, it seems as though the icon needs to be explicitly set. Without an icon set for one of our blocks, none of our blocks display at all.