### PR TITLE
Hotfix/date field bug

### DIFF
--- a/acf-json/group_594168e970d85.json
+++ b/acf-json/group_594168e970d85.json
@@ -39,7 +39,7 @@
                     "label": "Start Date",
                     "name": "start_date",
                     "type": "date_time_picker",
-                    "instructions": "Choose a start date for this block. This block will be hidden on the frontend, until the date and time selected.<br><br><strong>Note:</strong> For block expiration to work, both the Start Date and End Date must be set.",
+                    "instructions": "Choose a start date for this block. This block will be hidden on the frontend, until the date and time selected.<br><br><strong>Note:</strong> In order to use Start Date, both the Start Date and End Date must be set.",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -56,7 +56,7 @@
                     "label": "End Date",
                     "name": "end_date",
                     "type": "date_time_picker",
-                    "instructions": "Choose an end date for this block. This block will be display on the frontend, until the date and time selected.<br><br><strong>Note:</strong> For block expiration to work, both the Start Date and End Date must be set.",
+                    "instructions": "Choose an end date for this block. This block will be display on the frontend, until the date and time selected.<br><br><strong>Note:</strong> In order to use End Date, both the Start Date and End Date must be set.",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {

--- a/acf-json/group_594168e970d85.json
+++ b/acf-json/group_594168e970d85.json
@@ -39,7 +39,7 @@
                     "label": "Start Date",
                     "name": "start_date",
                     "type": "date_time_picker",
-                    "instructions": "Choose a start date for this block. This block will be hidden on the frontend, until the date and time selected.",
+                    "instructions": "Choose a start date for this block. This block will be hidden on the frontend, until the date and time selected.<br><br><strong>Note:</strong> For block expiration to work, both the Start Date and End Date must be set.",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -56,7 +56,7 @@
                     "label": "End Date",
                     "name": "end_date",
                     "type": "date_time_picker",
-                    "instructions": "Choose an end date for this block. This block will be display on the frontend, until the date and time selected.",
+                    "instructions": "Choose an end date for this block. This block will be display on the frontend, until the date and time selected.<br><br><strong>Note:</strong> For block expiration to work, both the Start Date and End Date must be set.",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -88,5 +88,5 @@
     "hide_on_screen": "",
     "active": 0,
     "description": "",
-    "modified": 1559330134
+    "modified": 1572973813
 }

--- a/inc/acf-gutenberg.php
+++ b/inc/acf-gutenberg.php
@@ -151,11 +151,15 @@ function _s_acf_block_registration_callback( $block ) {
 	// Convert the block name into a handy slug.
 	$block_slug = str_replace( 'acf/', '', $block['name'] );
 
+	// Make sure we have fields.
+	$start_date = isset( $block['data']['other_options_start_date'] ) ? $block['data']['other_options_start_date'] : '';
+	$end_date   = isset( $block['data']['other_options_end_date'] ) ? $block['data']['other_options_end_date'] : '';
+
 	// If the block has expired, then bail! But only on the frontend, so we can still see and edit the block in the backend.
 	if ( ! is_admin() && _s_has_block_expired(
 		array(
-			'start_date' => strtotime( $block['data']['other_options_start_date'], true ),
-			'end_date'   => strtotime( $block['data']['other_options_end_date'], true ),
+			'start_date' => strtotime( $start_date, true ),
+			'end_date'   => strtotime( $end_date, true ),
 		)
 	) ) {
 		return;

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -24,9 +24,24 @@ function _s_display_block_options( $args = array() ) {
 	$background_options = get_sub_field( 'background_options' ) ? get_sub_field( 'background_options' ) : get_field( 'background_options' )['background_options'];
 
 	// Get block other options.
-	$other_options = get_sub_field( 'other_options' ) ? get_sub_field( 'other_options' ) : get_field( 'other_options' )['other_options'];
+	$other_options = array();
 
-	$display_options = get_sub_field( 'display_options' ) ? get_sub_field( 'display_options' ) : get_field( 'display_options' )['display_options'];
+	// Set our Other Options if we have them. Some blocks may not.
+	if ( get_sub_field( 'other_options' ) ) {
+		$other_options = get_sub_field( 'other_options' );
+	} elseif ( get_field( 'other_options' ) ) {
+		$other_options = get_field( 'other_options' )['other_options'];
+	}
+
+	// Get block display options.
+	$display_options = array();
+
+	// Set our Display Options if we have them. Some blocks may not.
+	if ( get_sub_field( 'display_options' ) ) {
+		$display_options = get_sub_field( 'display_options' );
+	} elseif ( get_field( 'display_options' ) ) {
+		$display_options = get_field( 'display_options' )['display_options'];
+	}
 
 	// Get the block ID.
 	$block_id = _s_get_block_id( $args['block'] );

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -157,7 +157,7 @@ function _s_has_block_expired( $args = array() ) {
 	$args = wp_parse_args( $args, $defaults );
 
 	// Get (Unix) times and convert to integer.
-	$now   = (int) date( 'U' );
+	$now   = (int) current_time( 'timestamp' );
 	$start = (int) $args['start_date'];
 	$end   = (int) $args['end_date'];
 


### PR DESCRIPTION
### DESCRIPTION ###
@oliverharrison reported some `notices` being thrown on blocks when they didn't have Other Options or the Start/End Date fields added.

This update:
- Checks for the existence of Start/End Date before passing them into the `_s_has_block_expired` function
- Sets a default empty array for Other Options in the event a block doesn't have them available
- Sets a default empty array for Display Options in the event a block doesn't have them available
- Adds helper text to Start/End Date fields to specify that both are needed for block expiration to work
- Replaces `date( 'U' )` with `current_time( 'timestamp' )` so our `_s_has_block_expired` function function compares the block date values to the timezone of the current WP install (as set in Settings) rather than the server. For clarity, Oliver and I both had to set our expirations to 5 hours ahead while using `date( 'U' )` in our testing, but I was able to set my expiration a minute ahead using `current_time( 'timestamp' )` and have my block expire as expected per my WP timezone settings.

Let's kick the wheels on this a bunch and make sure things are working as expected for all scenarios!

### SCREENSHOTS ###
Updated descriptions:
![](https://dl.dropbox.com/s/ctgt76b1sohkwzq/Screenshot%202019-11-05%2011.37.53.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
**On `master`, No Options Set**
Create a block with no Other Options tab added, or remove the Other Options from an existing block.

Create the block and save your page, then view on the frontend.

You should see a notice similar to these:
```
Notice: Undefined index: other_options_start_date in /Applications/MAMP/htdocs/wd_s/wp-content/themes/wd_s/inc/acf-gutenberg.php on line 157

Notice: Undefined index: other_options_end_date in /Applications/MAMP/htdocs/wd_s/wp-content/themes/wd_s/inc/acf-gutenberg.php on line 158
```

**On `master`, Start/End Date Set**
Create a block with expiration dates/times. Note that the times don't align with what is set in the WP Settings.

-----

**On this branch**
Create a block with no Other Options tab added, or remove the Other Options from an existing block.

Create the block and save your page, then view on the frontend.

You should see the block with no notices, as our checks should be doing their jobs and falling back as needed.

**On this branch, Start/End Date Set**
Create a block with expiration dates/times. Note that the times should now align with the timezone as set in the WP Settings.

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

Yes, we'll need to update some code examples in the wiki.