### PR TITLE
Adds source map embed flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "polyfill": "uglifyjs src/js/babel-polyfill.min.js -m -o dist/js/babel-polyfill.js && uglifyjs src/js/babel-polyfill.min.js -m -c -o dist/js/babel-polyfill.min.js",
     "postinstall": "run-s build && composer install",
     "pot": "mkdirp dist/languages && wp-pot --src './*.php' --dest-file 'dist/languages/_s.pot'",
-    "scss": "node-sass src/scss/style.scss -o dist/css",
+    "scss": "node-sass src/scss/style.scss -o dist/css --source-map-embed true",
     "serve": "browser-sync start --https --proxy 'https://_s.test' --no-open --files \"dist/css/*.css, dist/js/*.js, **/*.html, **/*.php, !node_modules/**/*.html\"",
     "uglify": "mkdirp dist/js -p && uglifyjs src/js/concat/*.js -m -o dist/js/app.js && uglifyjs src/js/concat/*.js -m -c -o dist/js/app.min.js",
     "watch": "run-p serve watch:*",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "polyfill": "uglifyjs src/js/babel-polyfill.min.js -m -o dist/js/babel-polyfill.js && uglifyjs src/js/babel-polyfill.min.js -m -c -o dist/js/babel-polyfill.min.js",
     "postinstall": "run-s build && composer install",
     "pot": "mkdirp dist/languages && wp-pot --src './*.php' --dest-file 'dist/languages/_s.pot'",
-    "scss": "node-sass src/scss/style.scss -o dist/css --source-map-embed true",
+    "scss": "node-sass src/scss/style.scss -o dist/css --source-map-root file://${PWD}/ --source-map-embed true",
     "serve": "browser-sync start --https --proxy 'https://_s.test' --no-open --files \"dist/css/*.css, dist/js/*.js, **/*.html, **/*.php, !node_modules/**/*.html\"",
     "uglify": "mkdirp dist/js -p && uglifyjs src/js/concat/*.js -m -o dist/js/app.js && uglifyjs src/js/concat/*.js -m -c -o dist/js/app.min.js",
     "watch": "run-p serve watch:*",


### PR DESCRIPTION
Closes #516 

### DESCRIPTION ###
Adds the following flag to our `scss` script:
```--source-map-root file://${PWD}/ --source-map-embed true```

### SCREENSHOTS ###
**Before**
![before](https://d.pr/free/i/xEVoFS+)

**After**
![after](https://d.pr/free/i/fThbIm+)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Checkout the branch, run `npm run build` and inspect some elements. This was tested on wd_s as well as an active project, and both seem to be working as expected.

When you click on the partial link in the inspector for whatever element you're inspecting, you should be taken to the partial.

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

Nah.
