### PR TITLE
Update paths for slick-carousel calls

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -74,8 +74,8 @@ function _s_scripts() {
 
 	// Register styles & scripts.
 	wp_register_style( '_s-google-font', _s_font_url(), array(), null ); // @codingStandardsIgnoreLine - required to avoid Google caching issues.
-	wp_register_style( 'slick-carousel', get_template_directory_uri() . '/dist/slick/slick.css', null, '1.8.1' );
-	wp_register_script( 'slick-carousel', get_template_directory_uri() . '/dist/slick/slick' . $suffix . '.js', array( 'jquery' ), '1.8.1', true );
+	wp_register_style( 'slick-carousel', get_template_directory_uri() . '/dist/slick-carousel/slick/slick.css', null, '1.8.1' );
+	wp_register_script( 'slick-carousel', get_template_directory_uri() . '/dist/slick-carousel/slick/slick' . $suffix . '.js', array( 'jquery' ), '1.8.1', true );
 
 	// Enqueue styles.
 	wp_enqueue_style( '_s-google-font' );


### PR DESCRIPTION
Closes #525

### DESCRIPTION ###
- Updated paths for slick-carousel

### SCREENSHOTS ###


### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [ ] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?

### STEPS TO VERIFY ###
- After merge, view console of browser and see no more 404 error for slick-carousel assets

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?
