### PR TITLE
Removes source map to resolve a build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "polyfill": "uglifyjs src/js/babel-polyfill.min.js -m -o dist/js/babel-polyfill.js && uglifyjs src/js/babel-polyfill.min.js -m -c -o dist/js/babel-polyfill.min.js",
     "postinstall": "run-s frontend build",
     "pot": "mkdirp dist/languages && wp-pot --src './*.php' --dest-file 'dist/languages/_s.pot'",
-    "scss": "node-sass src/scss/style.scss -o dist/css --source-map-root file://${PWD}/ --source-map-embed true",
+    "scss": "node-sass src/scss/style.scss -o dist/css",
     "serve": "browser-sync start --https --proxy 'https://_s.test' --no-open --files \"dist/css/*.css, dist/js/*.js, **/*.html, **/*.php, !node_modules/**/*.html\"",
     "uglify": "mkdirp dist/js -p && uglifyjs src/js/concat/*.js -m -o dist/js/app.js && uglifyjs src/js/concat/*.js -m -c -o dist/js/app.min.js",
     "watch": "run-p serve watch:*",


### PR DESCRIPTION
Closes #527 & #528

### DESCRIPTION ###
Removes the source map functionality to resolve a temperamental build issue.

@gregrickaby suggested an alternate setup for source maps in #522, but the same issue persists with those changes.

### SCREENSHOTS ###
![cli screenshot](https://d.pr/i/ast9RV+)

### STEPS TO VERIFY ###
1. Check out the branch
  a. Try checking it in different directories. I only ran into the issue when checked out to my desktop
2. Run `npm i` to run the initial build and see if you receive the build errors seen above
