### PR TITLE
Beautifies the output of app.js for easier hunting down of issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "build:js": "run-s uglify polyfill customizer",
     "build:pot": "run-s pot",
     "clean": "rimraf dist/",
-    "customizer": "uglifyjs src/js/customizer.js -m -o dist/js/customizer.js && uglifyjs src/js/customizer.js -m -c -o dist/js/customizer.min.js",
+    "customizer": "uglifyjs src/js/customizer.js -m -b -o dist/js/customizer.js && uglifyjs src/js/customizer.js -m -c -o dist/js/customizer.min.js",
     "frontend": "frontend-dependencies",
     "gutenberg": "node-sass src/scss/gutenberg-blocks-style.scss -o dist/css",
     "icons": "svgo --config=.svgo.yml -f src/images/icons -o dist/images/icons && svgstore dist/images/icons/*.svg --inline -o dist/images/icons/sprite.svg",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "pot": "mkdirp dist/languages && wp-pot --src './*.php' --dest-file 'dist/languages/_s.pot'",
     "scss": "node-sass src/scss/style.scss -o dist/css",
     "serve": "browser-sync start --https --proxy 'https://_s.test' --no-open --files \"dist/css/*.css, dist/js/*.js, **/*.html, **/*.php, !node_modules/**/*.html\"",
-    "uglify": "mkdirp dist/js -p && uglifyjs src/js/concat/*.js -m -o dist/js/app.js && uglifyjs src/js/concat/*.js -m -c -o dist/js/app.min.js",
+    "uglify": "mkdirp dist/js -p && uglifyjs src/js/concat/*.js -m -b -o dist/js/app.js && uglifyjs src/js/concat/*.js -m -c -o dist/js/app.min.js",
     "watch": "run-p serve watch:*",
     "watch:css": "onchange \"src/scss\" -- run-p lint:scss build:scss",
     "watch:images": "onchange \"src/images\" -- run-p build:images",


### PR DESCRIPTION
Closes #523 

### DESCRIPTION ###
Adds the `-b` flag to both `app.js` and `customizer.js` output to beautify they for easier troubleshooting in dev mode.

We still need to move in the direction of source maps (similar to #522 which refers to stylesheets), but I think this is a good stop gap to help the troubleshooting process.

### SCREENSHOTS ###
**Before**
![console log before](https://d.pr/i/rLTaWh+)

**After**
![console log after](https://d.pr/i/kPzNp7+)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
1. Check it out
2. Throw some stuff into one of our `/concat/` files so you can track something in the console
3. Click the source and see where the code lives

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

Nah.