### PR TITLE
Pass the $custom_query to the pagination function

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -458,7 +458,6 @@ function _s_display_header_button() {
  * @author Corey Collins
  */
 function _s_display_numeric_pagination( $args = array(), $query = null ) {
-
 	global $wp;
 
 	if ( ! $query ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -458,7 +458,6 @@ function _s_display_header_button() {
  * @author Corey Collins
  */
 function _s_display_numeric_pagination( $args = array(), $query = null ) {
-	global $wp;
 
 	if ( ! $query ) {
 		global $wp_query;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -450,7 +450,8 @@ function _s_display_header_button() {
 /**
  * Displays numeric pagination on archive pages.
  *
- * @param array $args Array of params to customize output.
+ * @param array  $args Array of params to customize output.
+ * @param object $query The Query object; only passed if a custom WP_Query is used.
  *
  * @author WDS
  * @return void.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -456,13 +456,24 @@ function _s_display_header_button() {
  * @return void.
  * @author Corey Collins
  */
-function _s_display_numeric_pagination( $args = array() ) {
+function _s_display_numeric_pagination( $args = array(), $query = null ) {
+
+	global $wp;
+
+	if ( ! $query ) {
+		global $wp_query;
+		$query = $wp_query;
+	}
+
+	// Make the pagination work on custom query loops.
+	$total_pages = isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
 
 	// Set defaults.
 	$defaults = array(
 		'prev_text' => '&laquo;',
 		'next_text' => '&raquo;',
 		'mid_size'  => 4,
+		'total'     => $total_pages,
 	);
 
 	// Parse args.


### PR DESCRIPTION
https://github.com/WebDevStudios/wd_s/issues/535

### DESCRIPTION ###
- Added a parameter to the function to pass the $query object. All future queries that call the pagination function will have to add the custom query as a second parameter, ie: `_s_display_numeric_pagination( null, $the_query_name );`

### SCREENSHOTS ###
N/A

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
Create a custom query that has more posts than the currently-set posts_per_page and add the pagination function with the query name as a parameter. Check that pagination displays and function as expected.

### DOCUMENTATION ###
Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?
Probably, to explain the parameter that needs to be passed.
