### PR TITLE
Checks for background options before we try to use them

### DIFF
--- a/inc/acf-gutenberg.php
+++ b/inc/acf-gutenberg.php
@@ -360,7 +360,17 @@ function _s_get_block_expired_class() {
 		return;
 	}
 
-	$other_options = get_sub_field( 'other_options' ) ? get_sub_field( 'other_options' ) : get_field( 'other_options' )['other_options'];
+	$other_options = array();
+
+	if ( get_sub_field( 'other_options' ) ) {
+		$other_options = get_sub_field( 'other_options' );
+	} elseif ( isset( get_field( 'other_options' )['other_options'] ) ) {
+		$other_options = get_field( 'other_options' )['other_options'];
+	}
+
+	if ( empty( $other_options ) ) {
+		return;
+	}
 
 	if ( _s_has_block_expired(
 		array(

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -21,7 +21,13 @@ if ( ! class_exists( 'acf' ) ) {
 function _s_display_block_options( $args = array() ) {
 
 	// Get block background options.
-	$background_options = get_sub_field( 'background_options' ) ? get_sub_field( 'background_options' ) : get_field( 'background_options' )['background_options'];
+	$background_options = array();
+
+	if ( get_sub_field( 'background_options' ) ) {
+		$background_options = get_sub_field( 'background_options' );
+	} elseif ( get_field( 'background_options' ) ) {
+		$background_options = get_field( 'background_options' )['background_options'];
+	}
 
 	// Get block other options.
 	$other_options = array();
@@ -50,7 +56,7 @@ function _s_display_block_options( $args = array() ) {
 
 	// Setup defaults.
 	$defaults = array(
-		'background_type' => $background_options['background_type']['value'],
+		'background_type' => ! empty( $background_options ) ? $background_options['background_type']['value'] : 'none',
 		'container'       => 'section',
 		'class'           => 'content-block',
 		'font_color'      => $display_options['font_color'],

--- a/inc/acf.php
+++ b/inc/acf.php
@@ -25,7 +25,7 @@ function _s_display_block_options( $args = array() ) {
 
 	if ( get_sub_field( 'background_options' ) ) {
 		$background_options = get_sub_field( 'background_options' );
-	} elseif ( get_field( 'background_options' ) ) {
+	} elseif ( get_field( 'background_options' ) && isset( get_field( 'background_options' )['background_options'] ) ) {
 		$background_options = get_field( 'background_options' )['background_options'];
 	}
 
@@ -35,7 +35,7 @@ function _s_display_block_options( $args = array() ) {
 	// Set our Other Options if we have them. Some blocks may not.
 	if ( get_sub_field( 'other_options' ) ) {
 		$other_options = get_sub_field( 'other_options' );
-	} elseif ( get_field( 'other_options' ) ) {
+	} elseif ( get_field( 'other_options' ) && isset( get_field( 'other_options' )['other_options'] ) ) {
 		$other_options = get_field( 'other_options' )['other_options'];
 	}
 
@@ -47,7 +47,7 @@ function _s_display_block_options( $args = array() ) {
 	// Set our Display Options if we have them. Some blocks may not.
 	if ( get_sub_field( 'display_options' ) ) {
 		$display_options = get_sub_field( 'display_options' );
-	} elseif ( get_field( 'display_options' ) ) {
+	} elseif ( get_field( 'display_options' ) && isset( get_field( 'display_options' )['display_options'] ) ) {
 		$display_options = get_field( 'display_options' )['display_options'];
 	}
 


### PR DESCRIPTION
Closes #543

### DESCRIPTION ###
Adds a check to make sure we actually have background options before we try using them. Seems smart!

We're already doing this like 3 lines later with our Other Options and Display Options tabs, but background options seemed to miss the boat here.

### SCREENSHOTS ###
![look at that nice code](https://d.pr/i/GiY6m5+)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
**Test current**
1. Check out master
2. Edit a block's fields to remove Background, Other, and Display options in ACF (in my test, I just removed them from the Hero)
3. Add the block from step 2 to a page
4. Add another block you haven't touched to the same page
5. View the blocks on the frontend
6. Do you see PHP notices? Cool! This is the current scenario @richaber reported.

**Test this branch**
1. Check out this branch
2. Edit a block's fields to remove background, other, and display options (in my test, I just removed them from the Hero)
3. Add the block from step 2 to a page
4. Add another block you haven't touched to the same page
5. View the blocks on the frontend
6. Do you see PHP notices? If not, it works!

### DOCUMENTATION ###
No documentation update needed for this.
