### PR TITLE
Update to support php 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
   },
   "require-dev": {
     "phpcompatibility/php-compatibility": "~9.3",
-    "webdevstudios/php-coding-standards": "~1.1"
+    "webdevstudios/php-coding-standards": "~1.2.1"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb0cc6370ba7fa877ac766b5b90a6c91",
+    "content-hash": "746579b027e49cf0e1ad4435e24129cc",
     "packages": [],
     "packages-dev": [
         {
@@ -133,16 +133,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.2",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -175,31 +175,30 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-09-23T23:08:17+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "webdevstudios/php-coding-standards",
-            "version": "1.1.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WebDevStudios/php-coding-standards.git",
-                "reference": "7a2d2f5ee27b06df1fd292d5a55a7b6cfb468912"
+                "reference": "df0d63a81c0cd08b71348ca7017dba4e56c02c07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WebDevStudios/php-coding-standards/zipball/7a2d2f5ee27b06df1fd292d5a55a7b6cfb468912",
-                "reference": "7a2d2f5ee27b06df1fd292d5a55a7b6cfb468912",
+                "url": "https://api.github.com/repos/WebDevStudios/php-coding-standards/zipball/df0d63a81c0cd08b71348ca7017dba4e56c02c07",
+                "reference": "df0d63a81c0cd08b71348ca7017dba4e56c02c07",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-                "squizlabs/php_codesniffer": ">=3.3.1 <3.4.0",
-                "wp-coding-standards/wpcs": "2.1.1"
+                "wp-coding-standards/wpcs": "~2.3.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -211,28 +210,34 @@
             ],
             "authors": [
                 {
+                    "name": "WebDevStudios",
+                    "email": "contact@webdevstudios.com",
+                    "homepage": "http://webdevstudios.com",
+                    "role": "Company"
+                },
+                {
                     "name": "Aubrey Portwood",
                     "email": "aubrey@webdevstudios.com",
-                    "homepage": "http://webdevstudios.com/",
-                    "role": "Developer"
+                    "homepage": "http://twitter.com/aubreypwd",
+                    "role": "Project Lead & Developer"
                 }
             ],
             "description": "In-house PHP linting and coding standards for WebDevStudios",
             "homepage": "https://github.com/WebDevStudios/php-coding-standards",
-            "time": "2020-07-17T19:31:00+00:00"
+            "time": "2020-10-16T20:49:05+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
@@ -240,12 +245,13 @@
                 "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -255,7 +261,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -264,7 +270,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -91,7 +91,7 @@ function _s_copyright_year( $atts ) {
 		$atts
 	);
 
-	$current_year = date( 'Y' );
+	$current_year = gmdate( 'Y' );
 
 	// Return current year if starting year is empty.
 	if ( ! $args['starting_year'] ) {


### PR DESCRIPTION
No Ticket

### DESCRIPTION

- Updates to 1.2.0 of our php coding standards to support php 7.4

### OTHER

- [ ] ~Is this issue accessible? (Section 508/WCAG 2.0AA)~
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] ~Does this pass CBT?~

### STEPS TO VERIFY

- Clone
- `composer install`
- `composer run lint`

---

![wdsccsphp74](https://user-images.githubusercontent.com/1753298/96322673-3b2b2280-0fd7-11eb-9b1c-dcdf8ddee05e.gif)
