### PR TITLE
Convert css nano to conditional include

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,17 @@
-module.exports = {
-	plugins: [
-		require( 'tailwindcss' ),
-		require( 'autoprefixer' ),
+const plugins = [
+	require( 'tailwindcss' ),
+	require( 'autoprefixer' ),
+];
+
+// Include CSS Nano if production mode.
+if ( 'production' === process.env.NODE_ENV ) {
+	plugins.push(
 		require( 'cssnano' )( {
 			preset: 'default',
 		} ),
-	],
+	);
+}
+
+module.exports = {
+	plugins,
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,17 +1,9 @@
-const plugins = [
-	require( 'tailwindcss' ),
-	require( 'autoprefixer' ),
-];
-
-// Include CSS Nano if production mode.
-if ( 'production' === process.env.NODE_ENV ) {
-	plugins.push(
-		require( 'cssnano' )( {
-			preset: 'default',
-		} ),
-	);
-}
-
 module.exports = {
-	plugins,
+	plugins: [
+		require( 'tailwindcss' ),
+		require( 'autoprefixer' ),
+		'production' === process.env.NODE_ENV ? require( 'cssnano' )(
+			{ preset: 'default' }
+		) : false,
+	].filter( Boolean ),
 };


### PR DESCRIPTION
Does not have open issue, must be tested locally.

### DESCRIPTION

This feature improves performance when using `npm run start`. By preventing `css-nano` from running in development, rebuild times are quicker due to less processing needed.

### OTHER

- [NA] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [NA] Does this pass CBT?

### STEPS TO VERIFY

1. Before checking out this branch take an inventory of build times when using `npm run start` on `main`. Set steps below for details on rebuild.
1. Next, checkout this `feature/improve-build-tool-speed` and run `npm run start`. 
1. Once the script has built, edit an `@apply` css statement. Simply commenting out files may give false positives as these changes are incredibly fast regardless.
1. Verify that your `build/style-index` is unminified when using `npm run start`. 
1. Verify that your `build/style-index` is minified when using `npm run build`. 

### DOCUMENTATION

No additional documentation is required.

