### PR TITLE
Feature/css js organization

### DIFF
--- a/src/js-new/blocks/index.js
+++ b/src/js-new/blocks/index.js
@@ -1,0 +1,9 @@
+/**
+ * Gutenberg Block JS
+ *
+ * Import JS for Gutenberg blocks.
+ */
+
+// Custom Gutenberg Blocks.
+// import './wd';
+// import './acf';

--- a/src/js-new/global/index.js
+++ b/src/js-new/global/index.js
@@ -1,0 +1,10 @@
+/**
+ * Global JS
+ *
+ * Import JS that applies globally.
+ */
+
+import './js-enabled';
+import './window-ready';
+
+import './skip-link-focus-fix';

--- a/src/js-new/global/js-enabled.js
+++ b/src/js-new/global/js-enabled.js
@@ -1,0 +1,6 @@
+/**
+ * File js-enabled.js
+ *
+ * If Javascript is enabled, replace the <body> class "no-js".
+ */
+document.body.className = document.body.className.replace( 'no-js', 'js' );

--- a/src/js-new/global/skip-link-focus-fix.js
+++ b/src/js-new/global/skip-link-focus-fix.js
@@ -1,0 +1,44 @@
+/**
+ * File skip-link-focus-fix.js.
+ *
+ * Helps with accessibility for keyboard only users.
+ *
+ * @see https://git.io/vWdr2
+ */
+( function () {
+	const isWebkit = -1 < navigator.userAgent.toLowerCase().indexOf( 'webkit' ),
+		isOpera = -1 < navigator.userAgent.toLowerCase().indexOf( 'opera' ),
+		isIe = -1 < navigator.userAgent.toLowerCase().indexOf( 'msie' );
+
+	if (
+		( isWebkit || isOpera || isIe ) &&
+		document.getElementById &&
+		window.addEventListener
+	) {
+		window.addEventListener(
+			'hashchange',
+			function () {
+				const id = location.hash.substring( 1 );
+
+				if ( ! /^[A-z0-9_-]+$/.test( id ) ) {
+					return;
+				}
+
+				const element = document.getElementById( id );
+
+				if ( element ) {
+					if (
+						! /^(?:a|select|input|button|textarea)$/i.test(
+							element.tagName
+						)
+					) {
+						element.tabIndex = -1;
+					}
+
+					element.focus();
+				}
+			},
+			false
+		);
+	}
+} )();

--- a/src/js-new/global/window-ready.js
+++ b/src/js-new/global/window-ready.js
@@ -1,0 +1,21 @@
+/**
+ * File window-ready.js
+ *
+ * Add a "ready" class to <body> when window is ready.
+ *
+ * @author Greg Rickaby, Corey Collins
+ * @since January 31, 2020
+ */
+function wdsWindowReady() {
+	document.body.classList.add( 'ready' );
+}
+
+if (
+	( 'complete' === document.readyState ||
+		'loading' !== document.readyState ) &&
+	! document.documentElement.doScroll
+) {
+	wdsWindowReady();
+} else {
+	document.addEventListener( 'DOMContentLoaded', wdsWindowReady );
+}

--- a/src/js-new/index.js
+++ b/src/js-new/index.js
@@ -1,0 +1,9 @@
+/**
+ * Site JS
+ */
+
+import './global';
+
+import './template-tags';
+import './templates';
+import './blocks';

--- a/src/js-new/template-tags/index.js
+++ b/src/js-new/template-tags/index.js
@@ -1,0 +1,7 @@
+/**
+ * Template Tag JS
+ *
+ * JS for functions in template-tags.php.
+ */
+
+// import './function-name';

--- a/src/js-new/templates/index.js
+++ b/src/js-new/templates/index.js
@@ -1,0 +1,8 @@
+/**
+ * Template JS
+ *
+ * JS for WordPress template files.
+ * See https://developer.wordpress.org/themes/basics/template-files/.
+ */
+
+// import './template-name';

--- a/src/scss-new/blocks/_example.scss
+++ b/src/scss-new/blocks/_example.scss
@@ -1,0 +1,49 @@
+//----------------------------------------
+// Block Name - Type Of Block
+//----------------------------------------
+
+// Wide width block with bottom margin on the outer most element.
+// ┌────────────────────────────────────┐
+// │page                                │
+// │     ┌────────────────────────┐     │
+// │     │                        │     │
+// │     │block                   │     │
+// │     ├────────────────────────┤     │
+// │     │margin                  │     │
+// │     └────────────────────────┘     │
+// │                                    │
+// └────────────────────────────────────┘
+.wd-example {
+	@apply container mb-48;
+
+	&-title {
+		@apply font-serif text-3xl;
+	}
+
+	&-body {
+		@apply text-base;
+	}
+}
+
+// Full width block with inner padding and no bottom margin.
+// ┌────────────────────────────────────┐
+// │page                                │
+// ├────────────────────────────────────┤
+// │block                               │
+// │                                    │
+// │                                    │
+// │                                    │
+// ├────────────────────────────────────┤
+// │                                    │
+// └────────────────────────────────────┘
+.wd-another-example {
+	@apply py-48;
+
+	&-title {
+		@apply font-serif text-3xl;
+	}
+
+	&-body {
+		@apply text-base;
+	}
+}

--- a/src/scss-new/blocks/core/_code.scss
+++ b/src/scss-new/blocks/core/_code.scss
@@ -1,0 +1,13 @@
+//----------------------------------------
+// Code - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-code {
+	@apply container mb-16;
+
+	// TODO: Add support for typography sidebar options.
+
+	code {
+		@apply p-16; // TODO: Add font styles.
+	}
+}

--- a/src/scss-new/blocks/core/_gallery.scss
+++ b/src/scss-new/blocks/core/_gallery.scss
@@ -1,0 +1,33 @@
+//----------------------------------------
+// Gallery - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-gallery {
+	@apply container mb-96;
+
+	// TODO: Add toolbar option support.
+
+	.blocks-gallery-item {
+		// TODO: Add caption font styles.
+		// .blocks-gallery-item__caption {}
+
+		img,
+		figcaption {
+			@apply rounded;
+		}
+	}
+
+	&.columns-1,
+	&.columns-2 {
+		.blocks-gallery-item {
+			// .blocks-gallery-item__caption {}
+		}
+	}
+
+	&.columns-5,
+	&.columns-6 {
+		.blocks-gallery-item {
+			// .blocks-gallery-item__caption {}
+		}
+	}
+}

--- a/src/scss-new/blocks/core/_heading.scss
+++ b/src/scss-new/blocks/core/_heading.scss
@@ -1,0 +1,41 @@
+//----------------------------------------
+// Heading - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-heading {
+	@apply container;
+
+	// TODO: Add toolbar option support.
+
+	// TODO: Add heading font styles.
+	// h1,
+	// h2,
+	// h3,
+	// h4,
+	// h5,
+	// h6 {}
+
+	h1 {
+		@apply mb-32;
+	}
+
+	h2 {
+		@apply mb-24;
+	}
+
+	h3 {
+		@apply mb-20;
+	}
+
+	h4 {
+		@apply mb-16;
+	}
+
+	h5 {
+		@apply mb-12;
+	}
+
+	h6 {
+		@apply mb-8;
+	}
+}

--- a/src/scss-new/blocks/core/_image.scss
+++ b/src/scss-new/blocks/core/_image.scss
@@ -1,0 +1,12 @@
+//----------------------------------------
+// Image - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-image {
+	@apply container;
+
+	// TODO: Add toolbar and sidebar option support.
+
+	// TODO: Add figcaption font styles.
+	// figcaption {}
+}

--- a/src/scss-new/blocks/core/_list.scss
+++ b/src/scss-new/blocks/core/_list.scss
@@ -1,0 +1,25 @@
+//----------------------------------------
+// List - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-list {
+	@apply container; // TODO: Add list font styles.
+
+	// TODO: Add toolbar and sidebar option support.
+
+	ul {
+		@apply mb-16 list-disc list-inside;
+	}
+
+	ol {
+		@apply mb-16 list-decimal list-inside;
+	}
+
+	li li,
+	li li li,
+	li li li li,
+	li li li li li,
+	li li li li li li {
+		@apply ml-16;
+	}
+}

--- a/src/scss-new/blocks/core/_paragraph.scss
+++ b/src/scss-new/blocks/core/_paragraph.scss
@@ -1,0 +1,21 @@
+//----------------------------------------
+// Paragraph - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-paragraph {
+	@apply container;
+
+	// TODO: Add toolbar and sidebar option support.
+
+	// TODO: Add paragraph font styles.
+	// p {}
+
+	a,
+	p a {
+		@apply underline; // TODO: Add link highlight color.
+	}
+
+	&:last-child {
+		@apply mb-96;
+	}
+}

--- a/src/scss-new/blocks/core/_pullquote.scss
+++ b/src/scss-new/blocks/core/_pullquote.scss
@@ -1,0 +1,17 @@
+//----------------------------------------
+// Pullquote - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-pullquote {
+	@apply container my-32;
+
+	// TODO: Add toolbar and sidebar option support.
+
+	blockquote > p {
+		@apply mb-16; // TODO: Add font styles.
+	}
+
+	blockquote > cite {
+		@apply not-italic; // TODO: Add font styles.
+	}
+}

--- a/src/scss-new/blocks/core/_quote.scss
+++ b/src/scss-new/blocks/core/_quote.scss
@@ -1,0 +1,17 @@
+//----------------------------------------
+// Quote - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-quote {
+	@apply container my-32;
+
+	// TODO: Add toolbar and sidebar option support.
+
+	p {
+		@apply mb-16; // TODO: Add font styles.
+	}
+
+	cite {
+		@apply not-italic; // TODO: Add font styles.
+	}
+}

--- a/src/scss-new/blocks/core/_spacer.scss
+++ b/src/scss-new/blocks/core/_spacer.scss
@@ -1,0 +1,7 @@
+//----------------------------------------
+// Spacer - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-spacer {
+	@apply container;
+}

--- a/src/scss-new/blocks/core/_table.scss
+++ b/src/scss-new/blocks/core/_table.scss
@@ -1,0 +1,74 @@
+//----------------------------------------
+// Table - Core Gutenberg Block
+//----------------------------------------
+
+.wp-block-table {
+	@apply container mb-24;
+
+	// TODO: Add toolbar and sidebar option support.
+
+	table {
+		@apply p-0 border-0 border-collapse w-full;
+
+		border-spacing: 0;
+
+		@screen desktop {
+			@apply border border-solid; // TODO: Add border color.
+		}
+
+		thead {
+			@apply hidden;
+
+			@screen desktop {
+				@apply table-row-group;
+			}
+		}
+
+		th,
+		td {
+			@apply p-8 text-center;
+
+			@screen desktop {
+				@apply table-cell;
+			}
+		}
+
+		td {
+			@apply block text-center border border-solid; // TODO: Add border color.
+
+			@screen desktop {
+				@apply table-cell;
+			}
+
+			&:last-child {
+				@apply border-b border-tertiary-darkest border-solid;
+			}
+
+			&::before {
+				@apply block uppercase;
+
+				content: attr( data-label );
+
+				@screen desktop {
+					@apply hidden;
+				}
+			}
+		}
+
+		th {
+			@apply tracking-widest uppercase border border-solid; // TODO: Add border color.
+
+			@screen tablet-portrait {
+				@apply table-cell;
+			}
+		}
+
+		tr {
+			@apply block mb-16;
+
+			@screen desktop {
+				@apply table-row mb-0;
+			}
+		}
+	}
+}

--- a/src/scss-new/blocks/core/index.scss
+++ b/src/scss-new/blocks/core/index.scss
@@ -1,0 +1,15 @@
+//----------------------------------------
+// Core Gutenberg Block Styles
+//
+// Import supported Core Gutenberg block partials.
+//----------------------------------------
+@import 'code';
+@import 'heading';
+@import 'image';
+@import 'list';
+@import 'paragraph';
+@import 'pullquote';
+@import 'quote';
+@import 'spacer';
+@import 'table';
+@import 'gallery';

--- a/src/scss-new/blocks/index.scss
+++ b/src/scss-new/blocks/index.scss
@@ -1,0 +1,12 @@
+//----------------------------------------
+// Gutenberg Block Styles
+//
+// Import Core and custom Gutenberg block partials.
+//----------------------------------------
+
+// Core Gutenberg Blocks.
+@import 'core/index.scss';
+
+// Custom Gutenberg Blocks.
+// @import 'wd/index.scss';
+// @import 'acf/index.scss';

--- a/src/scss-new/index.scss
+++ b/src/scss-new/index.scss
@@ -1,0 +1,18 @@
+//----------------------------------------
+// Tailwind Includes
+//----------------------------------------
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+// @layer base {
+// // Custom base styles if necessary.
+// // See https://tailwindcss.com/docs/adding-base-styles.
+// }
+
+//----------------------------------------
+// Theme Styles.
+//----------------------------------------
+@import 'template-tags/index.scss';
+@import 'templates/index.scss';
+@import 'blocks/index.scss';

--- a/src/scss-new/template-tags/index.scss
+++ b/src/scss-new/template-tags/index.scss
@@ -1,0 +1,7 @@
+//----------------------------------------
+// Template Tag Styles
+//
+// Import partials for functions in template-tags.php.
+//----------------------------------------
+
+// @import 'function-name';

--- a/src/scss-new/templates/index.scss
+++ b/src/scss-new/templates/index.scss
@@ -1,0 +1,8 @@
+//----------------------------------------
+// Template Styles
+//
+// Import partials for WordPress templates and template parts.
+// See https://developer.wordpress.org/themes/basics/template-files/.
+//----------------------------------------
+
+// @import 'template-name';


### PR DESCRIPTION
**THIS IS A WIP**

Closes #616, #621 

### DESCRIPTION

This is my proposal for #616.

### Why?
#### Currently, it's hard to understand how JS, SCSS, and PHP files relate to each other.
* For example, the mobile off-canvas navigation's markup is in `template-tags.php`, called by a function `_s_display_mobile_menu()` but it's styles and js are located in two separate files - `scss/modules/_mobile-menus.scss`, `components/mobile-menu.js`, `scss/modules/_off-canvas.scss` and `components/off-canvas.js`.
* If I needed to make changes to the mobile off canvas nav, I have to track down four different files.
* There are currently no sub directories in JS `components/` which leads to unorganized JS source files.



#### There is no longer a need for unscoped `base` styles now that we use Tailwind.
* Unscoped base styles go against the point of Tailwind. When building blocks, we should not have to worry about overriding existing styles. Here's a link to Tailwind docs talking about [why headings have no style by default](https://tailwindcss.com/docs/preflight#headings-are-unstyled).
* Instead of base styles, we should use [tailwindlabs / tailwindcss-typography](https://github.com/tailwindlabs/tailwindcss-typography) to style user generated content from WYSIWYG fields and style Gutenberg text blocks with scoped block specific stylesheets (see `src/scss/blocks/core/`).

### Why not atomic design?
* Atomic design is great for a JS framework component based system but there are two reasons I don't think it will work in wd_s.
  * Confusion created by WordPress nomenclature like template tags, blocks, templates.
    * `template tag == atomic molecule || atomic atom || atomic organism`, `gutenberg block == atomic atom || atomic molecule || atomic organism` and `template == atomic template || atomic page`. There is too much room for interpretation IMO and this might cause confusion.

### Proposal
I'm proposing the following structure. This structure makes it really easy to see how the different theme files relate to each other because they all follow the same naming convention.
```
sass/
├─ blocks/
│  ├─ core/
|  |  ├─ _heading.scss
|  |  ├─ _paragraph.scss
|  |  ├─ index.scss
│  ├─ acf/
|  |  ├─ _example-block.scss
|  |  ├─ index.scss
│  ├─ index.scss
├─ template-tags/
│  ├─ _accordion.scss
│  ├─ _button.scss
│  ├─ _card.scss
├─ templates/
│  ├─ _header.scss
│  ├─ _single.scss
```
```
js/
├─ blocks/
│  ├─ acf/
|  |  ├─ example-block.js
|  |  ├─ index.js
│  ├─ index.js
├─ global/
│  ├─ index.js
│  ├─ js-enabled.js
│  ├─ window-ready.js
├─ template-tags/
│  ├─ accordion.js
│  ├─ index.js
├─ templates/
│  ├─ single.js
│  ├─ index.js
```

### SCREENSHOTS

If we go in this direction, here's what VSCode's Command + P menu would look like for different things. 

A custom ACF gutenberg block called Testimonials:
![ 2021-04-22 at 13 42 51 ](https://user-images.githubusercontent.com/12365909/115761707-a41d9980-a370-11eb-80ca-0fae9ce6f1db.png)

Shared CPT single as well as a custom CPT single template for Recipes:
![ 2021-04-22 at 13 37 32 ](https://user-images.githubusercontent.com/12365909/115761542-6f114700-a370-11eb-9928-b6536cdabc36.png)

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA) N/A
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT? N/A

### STEPS TO VERIFY

Coming soon...

### DOCUMENTATION

Coming soon...
