### PR TITLE
Hotfix/svgo issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28462,8 +28462,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.0.3.tgz",
 			"integrity": "sha512-XGF1ovD+/u9yw5JAFMWVd0PRtU9HNNhVizbNn1CN0OlpENaeN9IFUhhK/JHxtvl3xaOHv/pjjP3msTLGH9RK6Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "5.2.1",
@@ -28599,8 +28598,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.0.3.tgz",
 			"integrity": "sha512-xN11CqH8oUmLbDd8/+0UU3rYuNNnF2PWedTrIDqcuZ9Lm+w3yEZJgzBv4XsZ4fS1R4c9oNBPhih0jdOxUCHpFg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
 			"version": "2.1.2",
@@ -28790,8 +28788,7 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
 			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-node": {
 			"version": "1.8.2",
@@ -28865,15 +28862,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
 			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -32814,8 +32809,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
 			"integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.4",
@@ -33168,8 +33162,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
 			"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -36448,8 +36441,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "26.0.0",
@@ -40813,8 +40805,7 @@
 			"version": "0.36.2",
 			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
 			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-unique-selectors": {
 			"version": "4.0.1",
@@ -43777,15 +43768,13 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-8.0.2.tgz",
 			"integrity": "sha512-TN1l93iVTXpF9NJstlvP7nOu9zY2k+mN0NSFQ/VEGz15ZIP9ohdDZTtCWHs5LjctAhSAzaILULGbgiM0ItId3A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
 			"integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
 			"version": "4.2.0",
@@ -46568,8 +46557,7 @@
 			"version": "7.4.5",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
 			"integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"x-is-string": {
 			"version": "0.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const CopyPlugin = require( 'copy-webpack-plugin' );
 const SVGSpritemapPlugin = require( 'svg-spritemap-webpack-plugin' );
 const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );
-const ImageminPlugin = require( 'imagemin-webpack-plugin' ).default;
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
 const ESLintPlugin = require( 'eslint-webpack-plugin' );
 const StylelintPlugin = require( 'stylelint-webpack-plugin' );
@@ -93,25 +92,6 @@ module.exports = {
 			},
 			sprite: {
 				prefix: false,
-			},
-		} ),
-
-		/**
-		 * Uses Imagemin to clean SVGs.
-		 *
-		 * @see https://www.npmjs.com/package/imagemin-webpack-plugin
-		 */
-		new ImageminPlugin( {
-			svgo: {
-				plugins: [
-					{ removeViewBox: false },
-					{ removeDimensions: true },
-					{
-						removeAttrs: {
-							attrs: '*:(stroke|fill):((?!^none$).)*',
-						},
-					},
-				],
 			},
 		} ),
 

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -28,17 +28,7 @@ module.exports = merge( common, {
 				quality: 70,
 				progressive: true,
 			},
-			svgo: {
-				plugins: [
-					{ removeViewBox: false },
-					{ removeDimensions: true },
-					{
-						removeAttrs: {
-							attrs: '*:(stroke|fill):((?!^none$).)*',
-						},
-					},
-				],
-			},
+			svgo: null,
 		} ),
 	],
 	optimization: {


### PR DESCRIPTION
### DESCRIPTION

@itsamoreh ran into this issue and fixed it on a project. This is me jumping in here to add his fix to wd_s!

The issue was that something with ImageMin running on SVGs/the SVG sprite was causing a bizarre issue where _sometimes_ SVG sprites wouldn't generate. It felt kind of hit or miss when Amor and I chatted yesterday.

Nevertheless, this removes SVGs from ImageMin completely. The SVG SpriteMap plugin (apparently) minifies on its own without an extra step/plugin being needed.

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY

1. Check out the branch
2. Run `npm run build`
3. Run `npm run watch` and add some SVG files

You should see no real change in how this should have always worked – the SVG sprite should be generated and any new SVG files added to the `/build/images/icons/` directory.

### DOCUMENTATION

No updates needed here.
