### PR TITLE
ISSUE-635 Escape the SVG with wp_kses

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -92,7 +92,41 @@ function _s_entry_footer() {
  * @author WDS
  */
 function _s_display_svg( $args = [] ) {
-	echo _s_get_svg( $args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
+	$kses_defaults = wp_kses_allowed_html( 'post' );
+	$svg_args      = array(
+		'svg'   => array(
+			'class'           => true,
+			'aria-hidden'     => true,
+			'aria-labelledby' => true,
+			'role'            => true,
+			'xmlns'           => true,
+			'width'           => true,
+			'height'          => true,
+			'viewbox'         => true, // <= Must be lower case!
+			'fill'            => true,
+		),
+		'g'     => array( 'fill' => true ),
+		'title' => array(
+			'title' => true,
+			'id'    => true,
+		),
+		'path'  => array(
+			'd'    => true,
+			'fill' => true,
+		),
+		'use'   => array(
+			'xlink:href' => true,
+		),
+	);
+	$allowed_tags  = array_merge(
+		$kses_defaults,
+		$svg_args
+	);
+
+	echo wp_kses(
+		_s_get_svg( $args ),
+		$allowed_tags
+	);
 }
 
 /**


### PR DESCRIPTION
https://github.com/WebDevStudios/wd_s/issues/653

### DESCRIPTION

Created an array of allowed SVG attributes to pass to `wp_kses()` in order to escape the SVG output for `_s_get_svg()`.

### SCREENSHOTS

![image](https://user-images.githubusercontent.com/18194487/118149800-e53d2280-b3df-11eb-925d-4daec9bb736b.png)


### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY

Insert an icon using `_s_display_svg` function. Verify that the icon renders and can be styled using CSS.

### DOCUMENTATION

N/A
