### PR TITLE
Feature/bulk dependabot 2021 06 07

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.1",
-		"wp-cli/wp-cli-bundle": "2.5.0",
-		"wp-coding-standards/wpcs": "~2.3.0"
+		"wp-cli/wp-cli-bundle": "^2.5.0",
+		"wp-coding-standards/wpcs": "^2.3.0"
 	},
 	"scripts": {
 		"format": "./vendor/bin/phpcbf --standard=.phpcs.xml --report=summary,source",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c8367f7c24ae6cf2860b375ca122cf1",
+    "content-hash": "bf32cbc65cf41465cbdec389415800f8",
     "packages": [
         {
             "name": "composer/installers",
@@ -156,16 +156,16 @@
     "packages-dev": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.9",
+            "version": "1.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5"
+                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
-                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/9fdb22c2e97a614657716178093cd1da90a64aa8",
+                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8",
                 "shasum": ""
             },
             "require": {
@@ -209,11 +209,6 @@
                 "ssl",
                 "tls"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.2.9"
-            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -228,20 +223,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-12T12:10:35+00:00"
+            "time": "2021-06-07T13:58:28+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "2.0.14",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "92b2ccbef65292ba9f2004271ef47c7231e2eed5"
+                "reference": "1845e6854aa3f37f2c6c24bc525541b00b8b28e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/92b2ccbef65292ba9f2004271ef47c7231e2eed5",
-                "reference": "92b2ccbef65292ba9f2004271ef47c7231e2eed5",
+                "url": "https://api.github.com/repos/composer/composer/zipball/1845e6854aa3f37f2c6c24bc525541b00b8b28e4",
+                "reference": "1845e6854aa3f37f2c6c24bc525541b00b8b28e4",
                 "shasum": ""
             },
             "require": {
@@ -276,7 +271,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -321,7 +316,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-21T15:03:37+00:00"
+            "time": "2021-06-07T14:03:06+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -522,11 +517,6 @@
                 "spdx",
                 "validator"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.5"
-            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -666,10 +656,6 @@
                 "stylecheck",
                 "tests"
             ],
-            "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
-            },
             "time": "2020-12-07T18:04:37+00:00"
         },
         {
@@ -732,11 +718,6 @@
                 "po",
                 "translation"
             ],
-            "support": {
-                "email": "oom@oscarotero.com",
-                "issues": "https://github.com/oscarotero/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.4"
-            },
             "funding": [
                 {
                     "url": "https://paypal.me/oscarotero",
@@ -812,10 +793,6 @@
                 "translations",
                 "unicode"
             ],
-            "support": {
-                "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.6.0"
-            },
             "time": "2019-11-13T10:30:21+00:00"
         },
         {
@@ -882,10 +859,6 @@
                 "json",
                 "schema"
             ],
-            "support": {
-                "issues": "https://github.com/justinrainbow/json-schema/issues",
-                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
-            },
             "time": "2020-05-27T16:41:55+00:00"
         },
         {
@@ -977,10 +950,6 @@
                 "mustache",
                 "templating"
             ],
-            "support": {
-                "issues": "https://github.com/bobthecow/mustache.php/issues",
-                "source": "https://github.com/bobthecow/mustache.php/tree/master"
-            },
             "time": "2019-11-23T21:40:31+00:00"
         },
         {
@@ -1022,10 +991,6 @@
             "keywords": [
                 "xml"
             ],
-            "support": {
-                "issues": "https://github.com/nb/oxymel/issues",
-                "source": "https://github.com/nb/oxymel/tree/master"
-            },
             "time": "2013-02-24T15:01:54+00:00"
         },
         {
@@ -1084,10 +1049,6 @@
                 "phpcs",
                 "standards"
             ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
-            },
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
@@ -1140,10 +1101,6 @@
                 "polyfill",
                 "standards"
             ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
-            },
             "time": "2021-02-15T10:24:51+00:00"
         },
         {
@@ -1194,10 +1151,6 @@
                 "standards",
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
-            },
             "time": "2021-02-15T12:58:46+00:00"
         },
         {
@@ -1242,10 +1195,6 @@
                 "container-interop",
                 "psr"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
-            },
             "time": "2021-03-05T17:36:06+00:00"
         },
         {
@@ -1343,16 +1292,16 @@
         },
         {
             "name": "rmccue/requests",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/Requests.git",
-                "reference": "afbe4790e4def03581c4a0963a1e8aa01f6030f1"
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/Requests/zipball/afbe4790e4def03581c4a0963a1e8aa01f6030f1",
-                "reference": "afbe4790e4def03581c4a0963a1e8aa01f6030f1",
+                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
                 "shasum": ""
             },
             "require": {
@@ -1395,7 +1344,7 @@
                 "iri",
                 "sockets"
             ],
-            "time": "2021-04-27T11:05:25+00:00"
+            "time": "2021-06-04T09:56:25+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -1444,10 +1393,6 @@
                 "parser",
                 "validator"
             ],
-            "support": {
-                "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/Seldaek",
@@ -1502,10 +1447,6 @@
             "keywords": [
                 "phar"
             ],
-            "support": {
-                "issues": "https://github.com/Seldaek/phar-utils/issues",
-                "source": "https://github.com/Seldaek/phar-utils/tree/master"
-            },
             "time": "2020-07-07T18:42:57+00:00"
         },
         {
@@ -1557,11 +1498,6 @@
                 "phpcs",
                 "standards"
             ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
             "time": "2021-04-09T00:54:41+00:00"
         },
         {
@@ -2427,9 +2363,6 @@
                 "interoperability",
                 "standards"
             ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3741,9 +3674,6 @@
             ],
             "description": "A simple YAML loader/dumper class for PHP (WP-CLI fork)",
             "homepage": "https://github.com/mustangostang/spyc/",
-            "support": {
-                "source": "https://github.com/wp-cli/spyc/tree/autoload"
-            },
             "time": "2017-04-25T11:26:20+00:00"
         },
         {
@@ -3855,10 +3785,6 @@
                 "cli",
                 "console"
             ],
-            "support": {
-                "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.12"
-            },
             "time": "2021-03-03T12:43:49+00:00"
         },
         {
@@ -4499,10 +4425,6 @@
                 }
             ],
             "description": "Programmatically edit a wp-config.php file.",
-            "support": {
-                "issues": "https://github.com/wp-cli/wp-config-transformer/issues",
-                "source": "https://github.com/wp-cli/wp-config-transformer/tree/v1.2.8"
-            },
             "time": "2020-11-12T08:08:10+00:00"
         },
         {
@@ -4549,11 +4471,6 @@
                 "standards",
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
-                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
-                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
-            },
             "time": "2020-05-13T23:57:56+00:00"
         }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"svg-spritemap-webpack-plugin": "3.9.1",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
 				"url-loader": "^4.1.1",
-				"webpack-merge": "^5.7.3"
+				"webpack-merge": "^5.8.0"
 			},
 			"engines": {
 				"node": ">=14",
@@ -25065,9 +25065,9 @@
 			}
 		},
 		"node_modules/webpack-merge": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.7.3.tgz",
-			"integrity": "sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
 			"dev": true,
 			"dependencies": {
 				"clone-deep": "^4.0.1",
@@ -46175,9 +46175,9 @@
 			}
 		},
 		"webpack-merge": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.7.3.tgz",
-			"integrity": "sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
 			"dev": true,
 			"requires": {
 				"clone-deep": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@arkweid/lefthook": "^0.7.6",
 				"@tailwindcss/postcss7-compat": "^2.1.4",
 				"@wordpress/prettier-config": "^1.0.5",
-				"@wordpress/scripts": "^16.1.1",
+				"@wordpress/scripts": "^16.1.2",
 				"browser-sync": "^2.26.14",
 				"clean-webpack-plugin": "^3.0.0",
 				"copy-webpack-plugin": "6.4.1",
@@ -3134,9 +3134,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.1.tgz",
-			"integrity": "sha512-fK0BYDW4+Ch3JqjC/mObnOKjhYNGrIotZjrY2PfAOckRR3sBWY3g4ujgx1sSlcAeNskhGDULylQWhuF+MvQ7bw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.2.tgz",
+			"integrity": "sha512-29M9yiZte+1gInnHmAvfRr8HaPrkm8c+kDX2PkO1IJ5trWOUFcM8sCG/Cxm0N+c+6EpE5ToxME0Ex8CgZ52IKA==",
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
@@ -3304,12 +3304,12 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.1.tgz",
-			"integrity": "sha512-ILKZaDslKwGe5pjgIXnT7vmgRsV9OOVOsZRJHBuAAg/mZzxklTRULRfqX8a6/oNQtDcsQc+njtQa+O7ZSNCGbg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.2.tgz",
+			"integrity": "sha512-8cXNX4anZul09Qh6wRTrQJND5hfcY7M9CzSowbnSr9utgw8hJ5Xn7M7ngzs4ScvadSuJ2SFfMEjXkJwGpPnL8w==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/base-styles": "^3.5.1",
+				"@wordpress/base-styles": "^3.5.2",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
@@ -3354,9 +3354,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "16.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.1.tgz",
-			"integrity": "sha512-dgf4d+wUgvOqwNAjHXDyX+HDwfPAHL5I4rPPLOGVLplOAOq8JKRTtySveTaFDa/ButshranFHbeOvKd4xBFFsQ==",
+			"version": "16.1.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.2.tgz",
+			"integrity": "sha512-u6QFrG19wRp7kL5EQ2TcZ50GtPgXH35IwWWW/iio3XBSAuc5IWq2NNorGlgVS/sR1HnvoAoCTVkfaN+fpBziZA==",
 			"dev": true,
 			"dependencies": {
 				"@svgr/webpack": "^5.2.0",
@@ -3365,7 +3365,7 @@
 				"@wordpress/eslint-plugin": "^9.0.6",
 				"@wordpress/jest-preset-default": "^7.0.5",
 				"@wordpress/npm-package-json-lint-config": "^4.0.5",
-				"@wordpress/postcss-plugins-preset": "^3.1.1",
+				"@wordpress/postcss-plugins-preset": "^3.1.2",
 				"@wordpress/prettier-config": "^1.0.5",
 				"@wordpress/stylelint-config": "^19.0.5",
 				"babel-jest": "^26.6.3",
@@ -28418,9 +28418,9 @@
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.1.tgz",
-			"integrity": "sha512-fK0BYDW4+Ch3JqjC/mObnOKjhYNGrIotZjrY2PfAOckRR3sBWY3g4ujgx1sSlcAeNskhGDULylQWhuF+MvQ7bw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.2.tgz",
+			"integrity": "sha512-29M9yiZte+1gInnHmAvfRr8HaPrkm8c+kDX2PkO1IJ5trWOUFcM8sCG/Cxm0N+c+6EpE5ToxME0Ex8CgZ52IKA==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
@@ -28535,12 +28535,12 @@
 			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.1.tgz",
-			"integrity": "sha512-ILKZaDslKwGe5pjgIXnT7vmgRsV9OOVOsZRJHBuAAg/mZzxklTRULRfqX8a6/oNQtDcsQc+njtQa+O7ZSNCGbg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.2.tgz",
+			"integrity": "sha512-8cXNX4anZul09Qh6wRTrQJND5hfcY7M9CzSowbnSr9utgw8hJ5Xn7M7ngzs4ScvadSuJ2SFfMEjXkJwGpPnL8w==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^3.5.1",
+				"@wordpress/base-styles": "^3.5.2",
 				"autoprefixer": "^10.2.5"
 			},
 			"dependencies": {
@@ -28567,9 +28567,9 @@
 			"dev": true
 		},
 		"@wordpress/scripts": {
-			"version": "16.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.1.tgz",
-			"integrity": "sha512-dgf4d+wUgvOqwNAjHXDyX+HDwfPAHL5I4rPPLOGVLplOAOq8JKRTtySveTaFDa/ButshranFHbeOvKd4xBFFsQ==",
+			"version": "16.1.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.2.tgz",
+			"integrity": "sha512-u6QFrG19wRp7kL5EQ2TcZ50GtPgXH35IwWWW/iio3XBSAuc5IWq2NNorGlgVS/sR1HnvoAoCTVkfaN+fpBziZA==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
@@ -28578,7 +28578,7 @@
 				"@wordpress/eslint-plugin": "^9.0.6",
 				"@wordpress/jest-preset-default": "^7.0.5",
 				"@wordpress/npm-package-json-lint-config": "^4.0.5",
-				"@wordpress/postcss-plugins-preset": "^3.1.1",
+				"@wordpress/postcss-plugins-preset": "^3.1.2",
 				"@wordpress/prettier-config": "^1.0.5",
 				"@wordpress/stylelint-config": "^19.0.5",
 				"babel-jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@arkweid/lefthook": "^0.7.6",
 		"@tailwindcss/postcss7-compat": "^2.1.4",
 		"@wordpress/prettier-config": "^1.0.5",
-		"@wordpress/scripts": "^16.1.1",
+		"@wordpress/scripts": "^16.1.2",
 		"browser-sync": "^2.26.14",
 		"clean-webpack-plugin": "^3.0.0",
 		"copy-webpack-plugin": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"svg-spritemap-webpack-plugin": "3.9.1",
 		"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
 		"url-loader": "^4.1.1",
-		"webpack-merge": "^5.7.3"
+		"webpack-merge": "^5.8.0"
 	},
 	"scripts": {
 		"build": "cross-env NODE_ENV=production wp-scripts build --config webpack.prod.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "wd_s",
+	"version": "2.1.0",
 	"private": true,
 	"description": "A starter theme from WebDevStudios.",
 	"author": "WebDevStudios <contact@webdevstudios.com>",


### PR DESCRIPTION
Closes NA

### DESCRIPTION

Bump the following Composer dependencies:

```bash
"wp-cli/wp-cli-bundle": "^2.5.0",
"wp-coding-standards/wpcs": "^2.3.0"
```

Bump the following Node dependencies:

```bash
"@wordpress/scripts": "^16.1.2",
"webpack-merge": "^5.8.0"
```

### SCREENSHOTS

Frontend:
![screenshot](https://dl.dropbox.com/s/k207jil9e5lop6u/Screen%20Shot%202021-06-07%20at%2009.52.47.png?dl=0)

Build:
![screenshot](https://dl.dropbox.com/s/6ysv28r9tkik59h/Screen%20Shot%202021-06-07%20at%2009.53.12.png?dl=0)

Lint:
![screenshot](https://dl.dropbox.com/s/02sxptnntd5nrmw/Screen%20Shot%202021-06-07%20at%2009.54.01.png?dl=0)

### STEPS TO VERIFY

How do we test this?
1. `gh pr checkout 669`
2. `npm ci`
3. `npm run build`
4. Verify the theme built correctly
