### PR TITLE
Asset build file - remove unused vars and add defaults if build file can't be found

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -11,27 +11,16 @@
  * @author WDS
  */
 function _s_scripts() {
-	/**
-	 * Global variable for IE.
-	 */
-	global $is_IE; // @codingStandardsIgnoreLine
+	$asset_file_path = __DIR__ . '/../build/index.asset.php';
 
-	/**
-	 * If WP is in script debug, or we pass ?script_debug in a URL - set debug to true.
-	 */
-	// phpcs:ignore WordPress.Security.NonceVerification -- CSRF OK
-	$debug = ( defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ) || ( isset( $_GET['script_debug'] ) ) ? true : false;
-	/**
-	 * If we are debugging the site, use a unique version every page load so as to ensure no cache issues.
-	 */
-	$version = '1.0.0';
-
-	/**
-	 * Should we load minified files?
-	 */
-	$suffix = ( true === $debug ) ? '' : '.min';
-
-	$asset_file = include __DIR__ . '/../build/index.asset.php';
+	if ( is_readable( $asset_file_path ) ) {
+		$asset_file = include $asset_file_path;
+	} else {
+		$asset_file = [
+			'version'      => '1.0.0',
+			'dependencies' => [],
+		];
+	}
 
 	// Register styles & scripts.
 	wp_enqueue_style( 'wd_s', get_stylesheet_directory_uri() . '/build/index.css', [], $asset_file['version'] );


### PR DESCRIPTION
This needs some testing, ~~I don't have the  asset files locally and they don't seem to build, so this is my workaround for it.~~
It also removes the `$version` / `$debug` vars, as they aren't used. 