### PR TITLE
Change wpautop disabling function to remove the filter 

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -369,18 +369,13 @@ add_filter( 'get_the_archive_title', '_s_remove_archive_title_prefix' );
 /**
  * Disables wpautop to remove empty p tags in rendered Gutenberg blocks.
  *
- * @param string $content The starting post content.
- * @return string The updated post content.
  * @author Corey Collins
  */
-function _s_remove_empty_p_tags_from_content( $content ) {
-
+function _s_disable_wpautop_for_gutenberg() {
 	// If we have blocks in place, don't add wpautop.
-	if ( has_blocks() ) {
-		return $content;
+	if ( has_filter( 'the_content', 'wpautop' ) && has_blocks() ) {
+		remove_filter( 'the_content', 'wpautop' );
 	}
-
-	return wpautop( $content );
 }
-remove_filter( 'the_content', 'wpautop' );
-add_filter( 'the_content', '_s_remove_empty_p_tags_from_content' );
+
+add_filter( 'init', '_s_disable_wpautop_for_gutenberg', 9 );


### PR DESCRIPTION
### DESCRIPTION

Rather than removing the default filter and either returning `wpautop( $content )` or `$content`, this instead will remove the filter when we want it removed.

This allows the theme to still have the correct expected behavior when adding `remove_filter( 'the_content', 'wpautop' )` elsewhere, because we are no longer overriding the filter.

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

