### PR TITLE
Update asset build path include to use dirname() rather than ../

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -11,7 +11,7 @@
  * @author WDS
  */
 function _s_scripts() {
-	$asset_file_path = __DIR__ . '/../build/index.asset.php';
+	$asset_file_path = dirname( __DIR__ ) . '/build/index.asset.php';
 
 	if ( is_readable( $asset_file_path ) ) {
 		$asset_file = include $asset_file_path;


### PR DESCRIPTION
Use `dirname()` to get parent dir rather than `../`.
