### PR TITLE
Update get_the_date() to use DATE_W3C

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -20,9 +20,9 @@ function _s_posted_on() {
 
 	$time_string = sprintf(
 		$time_string,
-		esc_attr( get_the_date( 'c' ) ),
+		esc_attr( get_the_date( DATE_W3C ) ),
 		esc_html( get_the_date() ),
-		esc_attr( get_the_modified_date( 'c' ) ),
+		esc_attr( get_the_modified_date( DATE_W3C ) ),
 		esc_html( get_the_modified_date() )
 	);
 


### PR DESCRIPTION
### DESCRIPTION

from upstream _s:
>get_the_date( 'c' ) will return the post date, which appears to be in local time (per the timezone setting), except that it appends +00:00. Therefore, it's technically the wrong time. Using DATE_W3C as the date format renders in the same format but appends the correct offset.

Also see: https://core.trac.wordpress.org/ticket/20973

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?
