### PR TITLE
Update default deps for asset file when built file can't load

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -18,7 +18,7 @@ function _s_scripts() {
 	} else {
 		$asset_file = [
 			'version'      => '1.0.0',
-			'dependencies' => [],
+			'dependencies' => [ 'wp-polyfill' ],
 		];
 	}
 


### PR DESCRIPTION
### DESCRIPTION

Fallback was added in https://github.com/WebDevStudios/wd_s/commit/abb4de71340ea63fb62585605845e6f2f28b0ef8. This updates it to match the dependencies to what gets populated in that asset file.

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?
