### PR TITLE
Adds new step to find/replace setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If you want to set me up manually:
 You'll need to change all instances of the names: `_s`.
 
 - Search for: `'_s'` and replace with: `'project-name'` (inside single quotations) to capture the text domain
+- Search for: `"_s"` and replace with: `"project-name"` (inside double quotations) to capture the text domain
 - Search for: `_s_` and replace with: `project-name_` to capture all the function names
 - Search for: `Text Domain: _s` and replace with: `Text Domain: project-name` in style.css
 - Search for (and include the leading space): ` _s` and replace with: ` Project Name` (with a space before it) to capture DocBlocks


### PR DESCRIPTION
Closes #699. Props to @RichKenyon for the original issue.

### DESCRIPTION

This adds the additional line of checking for `"_s"` and replacing it with your project string, which is an instance found in the new `phpcs.xml.dist` file. Searching through the theme, this is the only spot where this string is found with double quotes so there doesn't appear to be anything that would be replaced where it shouldn't be.

@gregrickaby – will this require an update to the generator repo so find and replace this string as well?

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY

1. Look at the readme to confirm new step is in place
2. Check out the branch
3. Run a find for `"_s"` to confirm instances found in `phpcs.xml.dist`
4. Verify there are no unexpected or breaking instances of finding `"_s"` 

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

Yes – I'll add an update to the wiki now since we need to add this step regardless.