### PR TITLE
Basic WordPress hardening

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,7 @@ function _s_get_theme_include_files() {
 		'inc/customizer/customizer.php', // Customizer additions.
 		'inc/extras.php', // Custom functions that act independently of the theme templates.
 		'inc/hooks.php', // Load custom filters and hooks.
+		'inc/security.php', // WordPress hardening.
 		'inc/scaffolding.php', // Scaffolding.
 		'inc/scripts.php', // Load styles and scripts.
 		'inc/template-tags.php', // Custom template tags for this theme.

--- a/inc/security.php
+++ b/inc/security.php
@@ -24,7 +24,7 @@ add_filter( 'the_generator', '__return_false' );
 add_filter( 'xmlrpc_enabled', '__return_false' );
 
 /**
- * Change default from "null" to "*".
+ * Change REST-API header from "null" to "*".
  *
  * @author WebDevStudios
  * @see https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null

--- a/inc/security.php
+++ b/inc/security.php
@@ -29,7 +29,7 @@ add_filter( 'xmlrpc_enabled', '__return_false' );
  * @author WebDevStudios
  * @see https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null
  */
-function wds_ts_cors_control() {
+function _s_cors_control() {
 	header( 'Access-Control-Allow-Origin: *' );
 }
-add_action( 'rest_api_init', 'wds_ts_cors_control' );
+add_action( 'rest_api_init', '_s_cors_control' );

--- a/inc/security.php
+++ b/inc/security.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Security functions.
+ *
+ * Enable or disable certain functionality to harden WordPress.
+ *
+ * @package _s
+ */
+
+/**
+ * Remove generator meta tags.
+ *
+ * @author WebDevStudios
+ * @see https://developer.wordpress.org/reference/functions/the_generator/
+ */
+add_filter( 'the_generator', '__return_false' );
+
+/**
+ * Disable XML RPC.
+ *
+ * @author WebDevStudios
+ * @see https://developer.wordpress.org/reference/hooks/xmlrpc_enabled/
+ */
+add_filter( 'xmlrpc_enabled', '__return_false' );
+
+/**
+ * Change default from "null" to "*".
+ *
+ * @author WebDevStudios
+ * @see https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null
+ */
+function wds_ts_cors_control() {
+	header( 'Access-Control-Allow-Origin: *' );
+}
+add_action( 'rest_api_init', 'wds_ts_cors_control' );


### PR DESCRIPTION
Closes N/A

### DESCRIPTION

One of our clients was recently put through a security audit and I had to make some updates in order to make them compliant. I'm simply bringing these updates back to wd_s.

- Remove generator meta tags
- Disable XML RPC
- Change default REST-API headers from `null` to `*`

_Note: this PR is not an exhaustive list of ways to secure WordPress, but rather a starting point... so we can provide our future clients peace of mind._

### SCREENSHOTS

![screenshot](https://dl.dropbox.com/s/0eit8gh8fcb4ktw/Screen%20Shot%202021-06-30%20at%2012.40.24.png?dl=0)

### STEPS TO VERIFY

1. `gh pr checkout 709`
2. View the front-end and look for generator tags
3. Inspect any REST-API endpoint and verify the `Access-Control-Allow-Origin` is set to `*`
