### PR TITLE
Bulk Dependabot 2021 06 30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@arkweid/lefthook": "^0.7.6",
 				"@tailwindcss/postcss7-compat": "^2.2.4",
 				"@wordpress/prettier-config": "^1.0.5",
-				"@wordpress/scripts": "^16.1.3",
+				"@wordpress/scripts": "^16.1.4",
 				"browser-sync": "^2.26.14",
 				"clean-webpack-plugin": "^3.0.0",
 				"copy-webpack-plugin": "6.4.1",
@@ -3229,9 +3229,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.3.tgz",
-			"integrity": "sha512-xHTYc3mJFPtQJH5x6vj42VegSkalKf4LIonHnC3e77zV5oKOcmYltgruGPW4a6uXrek3tqiBLC8+4cL7DYcXmQ==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.4.tgz",
+			"integrity": "sha512-5JfLnkQMqaefuoMkqUJMBC8m9RpXJqaaOykxuy9y3uk+s2ENbMGXSUjbzw+anO3SIRORKnHmRkgofcSoqvWV5w==",
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
@@ -3399,12 +3399,12 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.3.tgz",
-			"integrity": "sha512-X0fzam0s+mK03Joe20LO0XAvrUUqTGmWEpMB0dyxh1RzzNqDeWbabiX5Bej6M9xze/HsF6net73ENHuz7jsZ7g==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.4.tgz",
+			"integrity": "sha512-yfzn2AKjHuFAPJL7NlUaga2KEWfBO5Pv9zhu0Km44pV/4Z/lUKu5m8Tqcllx6kUiERakMyvaXkAm0e0p+7oh5w==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/base-styles": "^3.5.3",
+				"@wordpress/base-styles": "^3.5.4",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
@@ -3438,25 +3438,6 @@
 				"postcss": "^8.1.0"
 			}
 		},
-		"node_modules/@wordpress/postcss-plugins-preset/node_modules/postcss": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-			"integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"colorette": "^1.2.2",
-				"nanoid": "^3.1.23",
-				"source-map-js": "^0.6.2"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
 		"node_modules/@wordpress/prettier-config": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.0.5.tgz",
@@ -3467,9 +3448,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "16.1.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.3.tgz",
-			"integrity": "sha512-AqKpKl3QWlVZk/eCgpsI1EZWW+dkcIck3JA1wQ/Fs2FjribmKhkzpQ2diLaK8ZqnFLtmb9UlTGnVmZ8uJLbBBA==",
+			"version": "16.1.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.4.tgz",
+			"integrity": "sha512-onjnFkshfGO5ecKEI7gG22F851/GVZTjffXamPaJBYiv2a1u05bDD8i9fjJduBcyQP2O2Qy1B8droC4uL7Epvw==",
 			"dev": true,
 			"dependencies": {
 				"@svgr/webpack": "^5.2.0",
@@ -3478,7 +3459,7 @@
 				"@wordpress/eslint-plugin": "^9.0.6",
 				"@wordpress/jest-preset-default": "^7.0.5",
 				"@wordpress/npm-package-json-lint-config": "^4.0.5",
-				"@wordpress/postcss-plugins-preset": "^3.1.3",
+				"@wordpress/postcss-plugins-preset": "^3.1.4",
 				"@wordpress/prettier-config": "^1.0.5",
 				"@wordpress/stylelint-config": "^19.0.5",
 				"babel-jest": "^26.6.3",
@@ -28688,8 +28669,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.0.5.tgz",
 			"integrity": "sha512-1xzZGFV5Bwox4XcE59I88q0/robJ35LoQNkKPC4tmfzd1XaAoJCZpp5T8LSJJtKKloeoO1JstrvMf3ltZLQ5IA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.2.0",
@@ -28712,9 +28692,9 @@
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.3.tgz",
-			"integrity": "sha512-xHTYc3mJFPtQJH5x6vj42VegSkalKf4LIonHnC3e77zV5oKOcmYltgruGPW4a6uXrek3tqiBLC8+4cL7DYcXmQ==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.4.tgz",
+			"integrity": "sha512-5JfLnkQMqaefuoMkqUJMBC8m9RpXJqaaOykxuy9y3uk+s2ENbMGXSUjbzw+anO3SIRORKnHmRkgofcSoqvWV5w==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
@@ -28826,16 +28806,15 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.0.5.tgz",
 			"integrity": "sha512-kckj06QsUe7fSGYWiOhsXbAgU2sL9s/gy7GynvQCqOPPiLGpJ8PvCx8OLMaT0T75CXFqieGvfS8Dtf+d84mFvg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.3.tgz",
-			"integrity": "sha512-X0fzam0s+mK03Joe20LO0XAvrUUqTGmWEpMB0dyxh1RzzNqDeWbabiX5Bej6M9xze/HsF6net73ENHuz7jsZ7g==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.1.4.tgz",
+			"integrity": "sha512-yfzn2AKjHuFAPJL7NlUaga2KEWfBO5Pv9zhu0Km44pV/4Z/lUKu5m8Tqcllx6kUiERakMyvaXkAm0e0p+7oh5w==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^3.5.3",
+				"@wordpress/base-styles": "^3.5.4",
 				"autoprefixer": "^10.2.5"
 			},
 			"dependencies": {
@@ -28852,18 +28831,6 @@
 						"normalize-range": "^0.1.2",
 						"postcss-value-parser": "^4.1.0"
 					}
-				},
-				"postcss": {
-					"version": "8.3.5",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-					"integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"colorette": "^1.2.2",
-						"nanoid": "^3.1.23",
-						"source-map-js": "^0.6.2"
-					}
 				}
 			}
 		},
@@ -28874,9 +28841,9 @@
 			"dev": true
 		},
 		"@wordpress/scripts": {
-			"version": "16.1.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.3.tgz",
-			"integrity": "sha512-AqKpKl3QWlVZk/eCgpsI1EZWW+dkcIck3JA1wQ/Fs2FjribmKhkzpQ2diLaK8ZqnFLtmb9UlTGnVmZ8uJLbBBA==",
+			"version": "16.1.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-16.1.4.tgz",
+			"integrity": "sha512-onjnFkshfGO5ecKEI7gG22F851/GVZTjffXamPaJBYiv2a1u05bDD8i9fjJduBcyQP2O2Qy1B8droC4uL7Epvw==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
@@ -28885,7 +28852,7 @@
 				"@wordpress/eslint-plugin": "^9.0.6",
 				"@wordpress/jest-preset-default": "^7.0.5",
 				"@wordpress/npm-package-json-lint-config": "^4.0.5",
-				"@wordpress/postcss-plugins-preset": "^3.1.3",
+				"@wordpress/postcss-plugins-preset": "^3.1.4",
 				"@wordpress/prettier-config": "^1.0.5",
 				"@wordpress/stylelint-config": "^19.0.5",
 				"babel-jest": "^26.6.3",
@@ -29011,8 +28978,7 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
 			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-node": {
 			"version": "1.8.2",
@@ -29089,15 +29055,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
 			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -33096,8 +33060,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
 			"integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.4",
@@ -33392,8 +33355,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
 			"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -35200,8 +35162,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -36702,8 +36663,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "26.0.0",
@@ -40453,8 +40413,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -40916,8 +40875,7 @@
 			"version": "0.36.2",
 			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
 			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-unique-selectors": {
 			"version": "4.0.1",
@@ -43849,15 +43807,13 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-8.0.2.tgz",
 			"integrity": "sha512-TN1l93iVTXpF9NJstlvP7nOu9zY2k+mN0NSFQ/VEGz15ZIP9ohdDZTtCWHs5LjctAhSAzaILULGbgiM0ItId3A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
 			"integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
 			"version": "4.2.0",
@@ -46709,8 +46665,7 @@
 			"version": "7.4.6",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
 			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"x-is-string": {
 			"version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"stylelint-config-prettier": "^8.0.2",
 				"stylelint-webpack-plugin": "^2.2.2",
 				"svg-spritemap-webpack-plugin": "3.9.1",
-				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
+				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.4",
 				"url-loader": "^4.1.1",
 				"webpack-merge": "^5.8.0"
 			},
@@ -2420,20 +2420,6 @@
 				"node": ">=12.13.0"
 			}
 		},
-		"node_modules/@tailwindcss/postcss7-compat/node_modules/fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@tailwindcss/postcss7-compat/node_modules/glob-parent": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
@@ -4152,15 +4138,6 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
-			}
 		},
 		"node_modules/atob": {
 			"version": "2.1.2",
@@ -10484,18 +10461,17 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs-minipass": {
@@ -10762,49 +10738,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"dependencies": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/glob-base/node_modules/glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
-			"dependencies": {
-				"is-glob": "^2.0.0"
-			}
-		},
-		"node_modules/glob-base/node_modules/is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/glob-base/node_modules/is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
-			"dependencies": {
-				"is-extglob": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -12436,15 +12369,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-extendable": {
@@ -16648,42 +16572,6 @@
 				"is-alphanumerical": "^1.0.0",
 				"is-decimal": "^1.0.0",
 				"is-hexadecimal": "^1.0.0"
-			}
-		},
-		"node_modules/parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
-			"dependencies": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/parse-glob/node_modules/is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/parse-glob/node_modules/is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
-			"dependencies": {
-				"is-extglob": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/parse-json": {
@@ -22808,40 +22696,45 @@
 		},
 		"node_modules/tailwindcss": {
 			"name": "@tailwindcss/postcss7-compat",
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.1.4.tgz",
-			"integrity": "sha512-KYRj/AGNwE4tPf02IvT+J36Twlrwg/OJJuSckSupX2T+xIOHSXPugNJZ7Stn9F67hh/qH+2Y2HXK6vpBadW6qw==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.4.tgz",
+			"integrity": "sha512-lFIBdD1D2w3RgHFg7kNB7U5LOlfbd+KXTzcLyC/RlQ9eVko6GjNCKpN/kdmfF9wiGxbSDT/3mousXeMZdOOuBg==",
 			"dev": true,
 			"dependencies": {
 				"@fullhuman/postcss-purgecss": "^3.1.3",
+				"arg": "^5.0.0",
 				"autoprefixer": "^9",
 				"bytes": "^3.0.0",
-				"chalk": "^4.1.0",
-				"chokidar": "^3.5.1",
+				"chalk": "^4.1.1",
+				"chokidar": "^3.5.2",
 				"color": "^3.1.3",
+				"cosmiconfig": "^7.0.0",
 				"detective": "^5.2.0",
 				"didyoumean": "^1.2.1",
 				"dlv": "^1.1.3",
 				"fast-glob": "^3.2.5",
-				"fs-extra": "^9.1.0",
+				"fs-extra": "^10.0.0",
+				"glob-parent": "^6.0.0",
 				"html-tags": "^3.1.0",
+				"is-glob": "^4.0.1",
 				"lodash": "^4.17.21",
 				"lodash.topath": "^4.5.2",
-				"modern-normalize": "^1.0.0",
+				"modern-normalize": "^1.1.0",
 				"node-emoji": "^1.8.1",
 				"normalize-path": "^3.0.0",
-				"object-hash": "^2.1.1",
-				"parse-glob": "^3.0.4",
+				"object-hash": "^2.2.0",
 				"postcss": "^7",
 				"postcss-functions": "^3",
 				"postcss-js": "^2",
+				"postcss-load-config": "^3.1.0",
 				"postcss-nested": "^4",
-				"postcss-selector-parser": "^6.0.4",
+				"postcss-selector-parser": "^6.0.6",
 				"postcss-value-parser": "^4.1.0",
 				"pretty-hrtime": "^1.0.3",
 				"quick-lru": "^5.1.1",
 				"reduce-css-calc": "^2.1.8",
-				"resolve": "^1.20.0"
+				"resolve": "^1.20.0",
+				"tmp": "^0.2.1"
 			},
 			"bin": {
 				"tailwind": "lib/cli.js",
@@ -22849,6 +22742,18 @@
 			},
 			"engines": {
 				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/glob-parent": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
+			"integrity": "sha512-Hdd4287VEJcZXUwv1l8a+vXC1GjOQqXe+VS30w/ypihpcnu9M1n3xeYeJu5CBpeEQj2nAab2xxz28GuA3vp4Ww==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/tapable": {
@@ -27984,17 +27889,6 @@
 				"tmp": "^0.2.1"
 			},
 			"dependencies": {
-				"fs-extra": {
-					"version": "10.0.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-					"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^6.0.1",
-						"universalify": "^2.0.0"
-					}
-				},
 				"glob-parent": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
@@ -29385,12 +29279,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
-		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
 			"dev": true
 		},
 		"atob": {
@@ -34403,12 +34291,11 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
@@ -34612,42 +34499,6 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"glob-parent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^2.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
 			}
 		},
 		"glob-parent": {
@@ -35919,12 +35770,6 @@
 			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
 			"dev": true,
 			"optional": true
-		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
 		},
 		"is-extendable": {
 			"version": "0.1.1",
@@ -39183,35 +39028,6 @@
 				"is-alphanumerical": "^1.0.0",
 				"is-decimal": "^1.0.0",
 				"is-hexadecimal": "^1.0.0"
-			}
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
 			}
 		},
 		"parse-json": {
@@ -44159,40 +43975,56 @@
 			}
 		},
 		"tailwindcss": {
-			"version": "npm:@tailwindcss/postcss7-compat@2.1.4",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.1.4.tgz",
-			"integrity": "sha512-KYRj/AGNwE4tPf02IvT+J36Twlrwg/OJJuSckSupX2T+xIOHSXPugNJZ7Stn9F67hh/qH+2Y2HXK6vpBadW6qw==",
+			"version": "npm:@tailwindcss/postcss7-compat@2.2.4",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.4.tgz",
+			"integrity": "sha512-lFIBdD1D2w3RgHFg7kNB7U5LOlfbd+KXTzcLyC/RlQ9eVko6GjNCKpN/kdmfF9wiGxbSDT/3mousXeMZdOOuBg==",
 			"dev": true,
 			"requires": {
 				"@fullhuman/postcss-purgecss": "^3.1.3",
+				"arg": "^5.0.0",
 				"autoprefixer": "^9",
 				"bytes": "^3.0.0",
-				"chalk": "^4.1.0",
-				"chokidar": "^3.5.1",
+				"chalk": "^4.1.1",
+				"chokidar": "^3.5.2",
 				"color": "^3.1.3",
+				"cosmiconfig": "^7.0.0",
 				"detective": "^5.2.0",
 				"didyoumean": "^1.2.1",
 				"dlv": "^1.1.3",
 				"fast-glob": "^3.2.5",
-				"fs-extra": "^9.1.0",
+				"fs-extra": "^10.0.0",
+				"glob-parent": "^6.0.0",
 				"html-tags": "^3.1.0",
+				"is-glob": "^4.0.1",
 				"lodash": "^4.17.21",
 				"lodash.topath": "^4.5.2",
-				"modern-normalize": "^1.0.0",
+				"modern-normalize": "^1.1.0",
 				"node-emoji": "^1.8.1",
 				"normalize-path": "^3.0.0",
-				"object-hash": "^2.1.1",
-				"parse-glob": "^3.0.4",
+				"object-hash": "^2.2.0",
 				"postcss": "^7",
 				"postcss-functions": "^3",
 				"postcss-js": "^2",
+				"postcss-load-config": "^3.1.0",
 				"postcss-nested": "^4",
-				"postcss-selector-parser": "^6.0.4",
+				"postcss-selector-parser": "^6.0.6",
 				"postcss-value-parser": "^4.1.0",
 				"pretty-hrtime": "^1.0.3",
 				"quick-lru": "^5.1.1",
 				"reduce-css-calc": "^2.1.8",
-				"resolve": "^1.20.0"
+				"resolve": "^1.20.0",
+				"tmp": "^0.2.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
+					"integrity": "sha512-Hdd4287VEJcZXUwv1l8a+vXC1GjOQqXe+VS30w/ypihpcnu9M1n3xeYeJu5CBpeEQj2nAab2xxz28GuA3vp4Ww==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				}
 			}
 		},
 		"tapable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"prettier": "npm:@wordpress/prettier-config",
 				"sass-loader": "10.2.0",
 				"stylelint-config-prettier": "^8.0.2",
-				"stylelint-webpack-plugin": "^2.2.1",
+				"stylelint-webpack-plugin": "^2.2.2",
 				"svg-spritemap-webpack-plugin": "3.9.1",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
 				"url-loader": "^4.1.1",
@@ -22168,9 +22168,9 @@
 			}
 		},
 		"node_modules/stylelint-webpack-plugin": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/stylelint-webpack-plugin/-/stylelint-webpack-plugin-2.2.1.tgz",
-			"integrity": "sha512-zzbBtpSFkCtWX/I/bNN2q8tm5nY876R4qau/o0UynuYPZNaDZEzxtPQBGk+0feH61sXTt39WVm/j+oH6wBJlmA==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/stylelint-webpack-plugin/-/stylelint-webpack-plugin-2.2.2.tgz",
+			"integrity": "sha512-zfIsAF13xe6xuhwxZDFWQEmuVcxnRk9JFovyRL/23CWjPK1HLRw4QZdvo0Bz1bQZaDQA+6ha7cU0NO+LXaw4Mw==",
 			"dev": true,
 			"dependencies": {
 				"@types/stylelint": "^13.13.0",
@@ -43838,9 +43838,9 @@
 			}
 		},
 		"stylelint-webpack-plugin": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/stylelint-webpack-plugin/-/stylelint-webpack-plugin-2.2.1.tgz",
-			"integrity": "sha512-zzbBtpSFkCtWX/I/bNN2q8tm5nY876R4qau/o0UynuYPZNaDZEzxtPQBGk+0feH61sXTt39WVm/j+oH6wBJlmA==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/stylelint-webpack-plugin/-/stylelint-webpack-plugin-2.2.2.tgz",
+			"integrity": "sha512-zfIsAF13xe6xuhwxZDFWQEmuVcxnRk9JFovyRL/23CWjPK1HLRw4QZdvo0Bz1bQZaDQA+6ha7cU0NO+LXaw4Mw==",
 			"dev": true,
 			"requires": {
 				"@types/stylelint": "^13.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"eslint-webpack-plugin": "^2.5.4",
 				"file-loader": "^6.2.0",
 				"imagemin-webpack-plugin": "^2.4.2",
-				"mini-css-extract-plugin": "^1.6.0",
+				"mini-css-extract-plugin": "^1.6.2",
 				"npm-run-all": "^4.1.5",
 				"postcss-loader": "4.2.0",
 				"postcss-preset-env": "^6.7.0",
@@ -15135,9 +15135,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.0.tgz",
-			"integrity": "sha512-nPFKI7NSy6uONUo9yn2hIfb9vyYvkFu95qki0e21DQ9uaqNKDP15DGpK0KnV6wDroWxPHtExrdEwx/yDQ8nVRw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
+			"integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
 			"dev": true,
 			"dependencies": {
 				"loader-utils": "^2.0.0",
@@ -38006,9 +38006,9 @@
 			"dev": true
 		},
 		"mini-css-extract-plugin": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.0.tgz",
-			"integrity": "sha512-nPFKI7NSy6uONUo9yn2hIfb9vyYvkFu95qki0e21DQ9uaqNKDP15DGpK0KnV6wDroWxPHtExrdEwx/yDQ8nVRw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
+			"integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@tailwindcss/postcss7-compat": "^2.2.4",
 				"@wordpress/prettier-config": "^1.0.5",
 				"@wordpress/scripts": "^16.1.4",
-				"browser-sync": "^2.26.14",
+				"browser-sync": "^2.27.3",
 				"clean-webpack-plugin": "^3.0.0",
 				"copy-webpack-plugin": "6.4.1",
 				"cross-env": "^7.0.3",
@@ -5017,13 +5017,13 @@
 			"dev": true
 		},
 		"node_modules/browser-sync": {
-			"version": "2.26.14",
-			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.14.tgz",
-			"integrity": "sha512-3TtpsheGolJT6UFtM2CZWEcGJmI4ZEvoCKiKE2bvcDnPxRkhQT4nIGVtfiyPcoHKXGM0LwMOZmYJNWfiNfVXWA==",
+			"version": "2.27.3",
+			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.3.tgz",
+			"integrity": "sha512-kyU5t5Sbm0lwCZTM4r2TKO9opznOT/P8eorkwWF4leZkbIZGyZohbSBiifYEWWlElM/vCRRhN/AqBH/3sSfOUw==",
 			"dev": true,
 			"dependencies": {
-				"browser-sync-client": "^2.26.14",
-				"browser-sync-ui": "^2.26.14",
+				"browser-sync-client": "^2.27.3",
+				"browser-sync-ui": "^2.27.3",
 				"bs-recipes": "1.3.4",
 				"bs-snippet-injector": "^2.0.1",
 				"chokidar": "^3.5.1",
@@ -5061,9 +5061,9 @@
 			}
 		},
 		"node_modules/browser-sync-client": {
-			"version": "2.26.14",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.14.tgz",
-			"integrity": "sha512-be0m1MchmKv/26r/yyyolxXcBi052aYrmaQep5nm8YNMjFcEyzv0ZoOKn/c3WEXNlEB/KeXWaw70fAOJ+/F1zQ==",
+			"version": "2.27.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.3.tgz",
+			"integrity": "sha512-GaadUAfO0hmueUi5hikJQhv1Qdak4qc62WFWl+0MQcqWTKDFG4fFbjnXs/W/sDpcOHclXVbNZqx2l+LLwuNz5Q==",
 			"dev": true,
 			"dependencies": {
 				"etag": "1.8.1",
@@ -5076,9 +5076,9 @@
 			}
 		},
 		"node_modules/browser-sync-ui": {
-			"version": "2.26.14",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.14.tgz",
-			"integrity": "sha512-6oT1sboM4KVNnWCCJDMGbRIeTBw97toMFQ+srImvwQ6J5t9KMgizaIX8HcKLiemsUMSJkgGM9RVKIpq2UblgOA==",
+			"version": "2.27.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.3.tgz",
+			"integrity": "sha512-va7dNwF+BC9gBVuVYa07wZPWEp4mTgi8/08oXiAzH0aSXOciu7II/Pu0V1fOFhRWcoFQxP8EzRJ4JP9Drx8evQ==",
 			"dev": true,
 			"dependencies": {
 				"async-each-series": "0.1.1",
@@ -30085,13 +30085,13 @@
 			"dev": true
 		},
 		"browser-sync": {
-			"version": "2.26.14",
-			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.14.tgz",
-			"integrity": "sha512-3TtpsheGolJT6UFtM2CZWEcGJmI4ZEvoCKiKE2bvcDnPxRkhQT4nIGVtfiyPcoHKXGM0LwMOZmYJNWfiNfVXWA==",
+			"version": "2.27.3",
+			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.3.tgz",
+			"integrity": "sha512-kyU5t5Sbm0lwCZTM4r2TKO9opznOT/P8eorkwWF4leZkbIZGyZohbSBiifYEWWlElM/vCRRhN/AqBH/3sSfOUw==",
 			"dev": true,
 			"requires": {
-				"browser-sync-client": "^2.26.14",
-				"browser-sync-ui": "^2.26.14",
+				"browser-sync-client": "^2.27.3",
+				"browser-sync-ui": "^2.27.3",
 				"bs-recipes": "1.3.4",
 				"bs-snippet-injector": "^2.0.1",
 				"chokidar": "^3.5.1",
@@ -30151,9 +30151,9 @@
 			}
 		},
 		"browser-sync-client": {
-			"version": "2.26.14",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.14.tgz",
-			"integrity": "sha512-be0m1MchmKv/26r/yyyolxXcBi052aYrmaQep5nm8YNMjFcEyzv0ZoOKn/c3WEXNlEB/KeXWaw70fAOJ+/F1zQ==",
+			"version": "2.27.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.3.tgz",
+			"integrity": "sha512-GaadUAfO0hmueUi5hikJQhv1Qdak4qc62WFWl+0MQcqWTKDFG4fFbjnXs/W/sDpcOHclXVbNZqx2l+LLwuNz5Q==",
 			"dev": true,
 			"requires": {
 				"etag": "1.8.1",
@@ -30163,9 +30163,9 @@
 			}
 		},
 		"browser-sync-ui": {
-			"version": "2.26.14",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.14.tgz",
-			"integrity": "sha512-6oT1sboM4KVNnWCCJDMGbRIeTBw97toMFQ+srImvwQ6J5t9KMgizaIX8HcKLiemsUMSJkgGM9RVKIpq2UblgOA==",
+			"version": "2.27.3",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.3.tgz",
+			"integrity": "sha512-va7dNwF+BC9gBVuVYa07wZPWEp4mTgi8/08oXiAzH0aSXOciu7II/Pu0V1fOFhRWcoFQxP8EzRJ4JP9Drx8evQ==",
 			"dev": true,
 			"requires": {
 				"async-each-series": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@arkweid/lefthook": "^0.7.6",
 		"@tailwindcss/postcss7-compat": "^2.2.4",
 		"@wordpress/prettier-config": "^1.0.5",
-		"@wordpress/scripts": "^16.1.3",
+		"@wordpress/scripts": "^16.1.4",
 		"browser-sync": "^2.26.14",
 		"clean-webpack-plugin": "^3.0.0",
 		"copy-webpack-plugin": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"@tailwindcss/postcss7-compat": "^2.2.4",
 		"@wordpress/prettier-config": "^1.0.5",
 		"@wordpress/scripts": "^16.1.4",
-		"browser-sync": "^2.26.14",
+		"browser-sync": "^2.27.3",
 		"clean-webpack-plugin": "^3.0.0",
 		"copy-webpack-plugin": "6.4.1",
 		"cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"prettier": "npm:@wordpress/prettier-config",
 		"sass-loader": "10.2.0",
 		"stylelint-config-prettier": "^8.0.2",
-		"stylelint-webpack-plugin": "^2.2.1",
+		"stylelint-webpack-plugin": "^2.2.2",
 		"svg-spritemap-webpack-plugin": "3.9.1",
 		"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
 		"url-loader": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"stylelint-config-prettier": "^8.0.2",
 		"stylelint-webpack-plugin": "^2.2.2",
 		"svg-spritemap-webpack-plugin": "3.9.1",
-		"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
+		"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.4",
 		"url-loader": "^4.1.1",
 		"webpack-merge": "^5.8.0"
 	},

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"eslint-webpack-plugin": "^2.5.4",
 		"file-loader": "^6.2.0",
 		"imagemin-webpack-plugin": "^2.4.2",
-		"mini-css-extract-plugin": "^1.6.0",
+		"mini-css-extract-plugin": "^1.6.2",
 		"npm-run-all": "^4.1.5",
 		"postcss-loader": "4.2.0",
 		"postcss-preset-env": "^6.7.0",


### PR DESCRIPTION
Closes #703
Closes #706 
Closes #707 
Closes #708 

### DESCRIPTION

This PR updates the following Node dependencies:

```bash
 @wordpress/scripts                                            ^16.1.3  →  ^16.1.4     
 browser-sync                                                 ^2.26.14  →  ^2.27.3     
 mini-css-extract-plugin                                        ^1.6.0  →   ^1.6.2     
 stylelint-webpack-plugin                                       ^2.2.1  →   ^2.2.2     
 tailwindcss                   npm:@tailwindcss/postcss7-compat@^2.1.4  →   ^2.2.4     
```

### SCREENSHOTS

![screenshot](https://dl.dropbox.com/s/31f7thx700o7cb5/Screen%20Shot%202021-06-30%20at%2012.56.48.png?dl=0)

![screenshot](https://dl.dropbox.com/s/uafdmglcv6rd8ci/Screen%20Shot%202021-06-30%20at%2012.57.06.png?dl=0)

### STEPS TO VERIFY

1. `gh pr checkout 710`
2. `npm i --legacy-peer-deps --ignore-scripts`
3. `npm run build`
4. `npm run dev`
