### PR TITLE
Updates version of prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"npm-run-all": "^4.1.5",
 		"postcss-loader": "4.2.0",
 		"postcss-preset-env": "^6.7.0",
-		"prettier": "npm:@wordpress/prettier-config",
+		"prettier": "npm:wp-prettier@^2.2.1-beta-1",
 		"sass-loader": "10.2.0",
 		"stylelint-config-prettier": "^8.0.2",
 		"stylelint-webpack-plugin": "^2.2.2",


### PR DESCRIPTION
Closes #713

### DESCRIPTION
Updates Prettier version based on @gregrickaby and @dcooney suggestion.

Nothing seems to change as far as compatibility or workflow, so if this solves the problem some others were having – great! I'm going to be out for a long weekend wanted to at least get this PR up, if not tested, reviewed, and merged in before I become unavailable.

### SCREENSHOTS
<img width="689" alt="image" src="https://user-images.githubusercontent.com/954724/130140349-1c4e3565-1dd3-4ab1-aa3c-58150ee3eb65.png">

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY
1. Checkout
2. Run `npm i --legacy-peer-deps`
3. Run `npm run build`
4. Run `npm run watch` and `npm run start` and make changes to ensure everything works as expected

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

No updates needed.
