### PR TITLE
Feature/preload assets

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -99,3 +99,25 @@ function _s_copyright_year( $atts ) {
 }
 
 add_shortcode( '_s_copyright_year', '_s_copyright_year', 15 );
+
+/**
+ * Retrieve the URL of the custom logo uploaded, if one exists.
+ *
+ * @author Corey Collins
+ */
+function _s_get_custom_logo_url() {
+
+	$custom_logo_id = get_theme_mod( 'custom_logo' );
+
+	if ( ! $custom_logo_id ) {
+		return;
+	}
+
+	$custom_logo_image = wp_get_attachment_image_src( $custom_logo_id, 'full' );
+
+	if ( ! isset( $custom_logo_image[0] ) ) {
+		return;
+	}
+
+	return $custom_logo_image[0];
+}

--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -55,3 +55,17 @@ function _s_preload_scripts() {
 	<?php
 }
 add_action( 'wp_head', '_s_preload_scripts', 1 );
+
+/**
+ * Preload assets.
+ *
+ * @author Corey Collins
+ */
+function _s_preload_assets() {
+	?>
+	<?php if ( _s_get_custom_logo_url() ) : ?>
+		<link rel="preload" href="<?php echo esc_url( _s_get_custom_logo_url() ); ?>" as="image">
+	<?php endif; ?>
+	<?php
+}
+add_action( 'wp_head', '_s_preload_assets', 1 );


### PR DESCRIPTION
### DESCRIPTION

Preloads the custom logo and adds a hook to preload other assets, like fonts.

### SCREENSHOTS
<img width="749" alt="image" src="https://user-images.githubusercontent.com/954724/133643654-d6f7c2e4-067f-4605-953a-4fa7293bb4bf.png">

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY
1. Checkout the branch
2. Upload a site logo using the Customizer
3. Verify the logo is preloaded in the `head`
