### PR TITLE
Add aspect ratio classes

### DIFF
--- a/src/scss/global/_media.scss
+++ b/src/scss/global/_media.scss
@@ -6,6 +6,7 @@
 
 	// This is a Gutenberg image block, so the class is applied to a <figure> wrapper element.
 	&.wp-block-image {
+		
 		img {
 			@apply h-full object-cover;
 		}
@@ -13,6 +14,7 @@
 }
 
 .aspectratio {
+
 	&-1-1 {
 		@apply media-cover;
 		aspect-ratio: 1 / 1;

--- a/src/scss/global/_media.scss
+++ b/src/scss/global/_media.scss
@@ -1,0 +1,28 @@
+.aspect-ratio {
+
+	// 16x9.
+	&-box {
+		@apply w-full h-0 overflow-hidden relative bg-gray-50;
+
+		padding-top: 56.25%;
+
+		.aspect-media {
+			@apply absolute top-0 left-0 w-full h-full object-cover;
+
+			&.contain {
+				@apply object-contain;
+			}
+
+		}
+	}
+
+	// 4x3.
+	&-75 {
+		padding-top: 75%;
+	}
+
+	// Square.
+	&-100 {
+		padding-top: 100%;
+	}
+}

--- a/src/scss/global/_media.scss
+++ b/src/scss/global/_media.scss
@@ -1,28 +1,35 @@
-.aspect-ratio {
+.media-cover {
+	// This is a regular image with the class applied to the <img> element.
+	&:not( .wp-block-image ) {
+		@apply h-full object-cover;
+	}
 
-	// 16x9.
-	&-box {
-		@apply w-full h-0 overflow-hidden relative bg-gray-50;
-
-		padding-top: 56.25%;
-
-		.aspect-media {
-			@apply absolute top-0 left-0 w-full h-full object-cover;
-
-			&.contain {
-				@apply object-contain;
-			}
-
+	// This is a Gutenberg image block, so the class is applied to a <figure> wrapper element.
+	&.wp-block-image {
+		img {
+			@apply h-full object-cover;
 		}
 	}
+}
 
-	// 4x3.
-	&-75 {
-		padding-top: 75%;
+.aspectratio {
+	&-1-1 {
+		@apply media-cover;
+		aspect-ratio: 1 / 1;
 	}
 
-	// Square.
-	&-100 {
-		padding-top: 100%;
+	&-3-4 {
+		@apply media-cover;
+		aspect-ratio: 3 / 4;
+	}
+
+	&-4-3 {
+		@apply media-cover;
+		aspect-ratio: 4 / 3;
+	}
+
+	&-16-9 {
+		@apply media-cover;
+		aspect-ratio: 16 / 9;
 	}
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -10,3 +10,4 @@
 @import 'templates/index.scss';
 @import 'blocks/index.scss';
 @import 'wordpress-global/index.scss';
+@import 'global/media.scss';


### PR DESCRIPTION
Closes #762 

### DESCRIPTION
Adds ratio box classes that can be used for media (images, video). 

This adds a couple of standard sizes
16:9, 4:3, square

`.aspect-media` defaults to `object-fit: cover;` but can be overridden with a `.contain` class.

### SCREENSHOTS
From left to right:
16:9, 4:3, square

<img width="1208" alt="Screen Shot 2021-10-14 at 12 41 20 PM" src="https://user-images.githubusercontent.com/5550150/137361045-61161b8f-efbf-4cd1-88f1-c8cbb40a5b89.png">

For reference, here's the code from the screenshot above, and how it would be implemented.
```
<div class="col-span-4 card-image-wrapper aspect-ratio-box outline-black">
    <img class="aspect-media" src="https://via.placeholder.com/1200">
</div>
```

### QUESTIONS
- I decided to put the `media` scss file under global folder - thoughts?
- General question - I wasn't seeing where `global/_global.scss` is being @imported from is it being imported anywhere?

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY

How do we test this?

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?
