### PR TITLE
Disable annoyances in the edit post screen

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -182,3 +182,14 @@ function _s_widgets_init() {
 }
 
 add_action( 'widgets_init', '_s_widgets_init' );
+
+/**
+ * Disable default fullscreen editor functionality and hide the 'Welcome to the Block Editor' popup.
+ *
+ * @author WebDevStudios
+ */
+function _s_disable_editor_annoyances() {
+	$script = "window.onload = function() { wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ) && wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' ); wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) && wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' ); }";
+	wp_add_inline_script( 'wp-blocks', $script );
+}
+add_action( 'enqueue_block_editor_assets', '_s_disable_editor_annoyances' );


### PR DESCRIPTION
Closes #766 

### DESCRIPTION
Added a function that:
* disables the fullscreen editor permanently; it can be enabled for a single editing session but it will be disabled again on a new edit of a post or page
* disables the welcome popup that is displayed on first launch

### SCREENSHOTS
![image](https://user-images.githubusercontent.com/18194487/137389987-9af236e3-dc7e-4f3e-926e-3f67c12e98d6.png)



### OTHER

- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [ ] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?

### STEPS TO VERIFY

* Open a new editor that uses Gutenberg
* Verify that the edit screen does not enter full screen
* Verify that the 'Welcome to the Block Editor' popup does not appear

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?
Maybe - as this will affect clients if this function remains intact with any theme built with wd_s, it should be noted in the documentation that these elements are disabled.
