### PR TITLE
Feature/#770 posted on tweaks

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -59,35 +59,6 @@ function _s_post_author( $args = [] ) {
 	<?php
 }
 
-function _s_display_post_meta( $first = 'date', $date_meta = [], $byline_meta = [] ) {
-
-	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-		$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-	}
-
-	$time_string = sprintf(
-		$time_string,
-		esc_attr( get_the_date( DATE_W3C ) ),
-		esc_html( get_the_date() ),
-		esc_attr( get_the_modified_date( DATE_W3C ) ),
-		esc_html( get_the_modified_date() )
-	);
-
-	$date = sprintf(
-		/* translators: the date the post was published */
-		esc_html_x( 'Posted on %s', 'post date', '_s' ),
-		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
-	);
-
-	$byline = sprintf(
-		/* translators: the post author */
-		esc_html_x( 'by %s', 'post author', '_s' ),
-		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-	);
-
-}
-
 /**
  * Prints HTML with meta information for the categories, tags and comments.
  *

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -42,6 +42,70 @@ function _s_posted_on() {
 	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
 }
 
+/**
+ * Prints HTML with meta information for the current post-date/time and author.
+ *
+ * @author WebDevStudios
+ */
+function _s_posted_on_alt( $args = [] ) {
+
+	// Set defaults.
+	$defaults = [
+		'before_date'    => esc_html__( 'Post on', '_s' ),
+		'date_format'    => 'F j, Y',
+		'display_author' => true,
+		'before_author'      => esc_html__( 'by', '_s' ),
+		'reverse_order'  => false,
+	];
+
+	// Parse args.
+	$args = wp_parse_args( $args, $defaults );
+
+	?>
+
+	<span class="posted-on">
+		<?php echo esc_html( $args['before_date'] ); ?>
+		<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+			<time class="entry-date published" datetime="<?php echo esc_attr( get_the_date( DATE_W3C ) ); ?>">
+				<?php echo esc_html( get_the_time( $args['date_format'] ) ); ?>
+			</time>
+		</a>
+
+		<?php if ( isset( $args['display_author'] ) ) : ?>
+			<?php echo esc_html( $args['before_author'] )
+		<?php endif; ?>
+	</span>
+
+	 <?php
+		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+		}
+
+		$time_string = sprintf(
+			$time_string,
+			esc_attr( get_the_date( DATE_W3C ) ),
+			esc_html( get_the_date() ),
+			esc_attr( get_the_modified_date( DATE_W3C ) ),
+			esc_html( get_the_modified_date() )
+		);
+
+    $posted_on = sprintf(
+		/* translators: the date the post was published */
+		esc_html_x( 'Posted on %s', 'post date', '_s' ),
+		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
+    );
+
+    $byline = sprintf(
+		/* translators: the post author */
+		esc_html_x( 'by %s', 'post author', '_s' ),
+		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+    );
+
+	 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
+	 echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
+}
+
 function _s_display_post_meta( $first = 'date', $date_meta = [], $byline_meta = [] ) {
 
 	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -42,6 +42,35 @@ function _s_posted_on() {
 	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
 }
 
+function _s_display_post_meta( $first = 'date', $date_meta = [], $byline_meta = [] ) {
+
+	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+		$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+	}
+
+	$time_string = sprintf(
+		$time_string,
+		esc_attr( get_the_date( DATE_W3C ) ),
+		esc_html( get_the_date() ),
+		esc_attr( get_the_modified_date( DATE_W3C ) ),
+		esc_html( get_the_modified_date() )
+	);
+
+	$date = sprintf(
+		/* translators: the date the post was published */
+		esc_html_x( 'Posted on %s', 'post date', '_s' ),
+		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
+	);
+
+	$byline = sprintf(
+		/* translators: the post author */
+		esc_html_x( 'by %s', 'post author', '_s' ),
+		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+	);
+
+}
+
 /**
  * Prints HTML with meta information for the categories, tags and comments.
  *

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -8,9 +8,11 @@
  */
 
 /**
- * Prints HTML with meta information for the current post-date/time and author.
+ * Prints HTML with date information for the current post.
  *
  * @author WebDevStudios
+ *
+ * @param array $args Configuration args.
  */
 function _s_post_date( $args = [] ) {
 
@@ -34,9 +36,11 @@ function _s_post_date( $args = [] ) {
 
 
 /**
- * Prints HTML with meta information for the current post-date/time and author.
+ * Prints HTML with author information for the current post.
  *
  * @author WebDevStudios
+ *
+ * @param array $args Configuration args.
  */
 function _s_post_author( $args = [] ) {
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -12,98 +12,51 @@
  *
  * @author WebDevStudios
  */
-function _s_posted_on() {
-	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-		$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-	}
+function _s_post_date( $args = [] ) {
 
-	$time_string = sprintf(
-		$time_string,
-		esc_attr( get_the_date( DATE_W3C ) ),
-		esc_html( get_the_date() ),
-		esc_attr( get_the_modified_date( DATE_W3C ) ),
-		esc_html( get_the_modified_date() )
-	);
+	// Set defaults.
+	$defaults = [
+		'date_text'   => esc_html__( 'Posted on', '_s' ),
+		'date_format' => get_option( 'date_format' ),
+	];
 
-	$posted_on = sprintf(
-		/* translators: the date the post was published */
-		esc_html_x( 'Posted on %s', 'post date', '_s' ),
-		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
-	);
+	// Parse args.
+	$args = wp_parse_args( $args, $defaults );
 
-	$byline = sprintf(
-		/* translators: the post author */
-		esc_html_x( 'by %s', 'post author', '_s' ),
-		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-	);
-
-	 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
-	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
+	ob_start();
+	?>
+	<span class="posted-on">
+		<?php echo esc_html( $args['date_text'] . ' ' ); ?>
+		<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark"><time class="entry-date published" datetime="<?php echo esc_attr( get_the_date( DATE_W3C ) ); ?>"><?php echo esc_html( get_the_time( $args['date_format'] ) ); ?></time></a>
+	</span>
+	<?php
 }
+
 
 /**
  * Prints HTML with meta information for the current post-date/time and author.
  *
  * @author WebDevStudios
  */
-function _s_posted_on_alt( $args = [] ) {
+function _s_post_author( $args = [] ) {
 
 	// Set defaults.
 	$defaults = [
-		'before_date'    => esc_html__( 'Post on', '_s' ),
-		'date_format'    => 'F j, Y',
-		'display_author' => true,
-		'before_author'      => esc_html__( 'by', '_s' ),
-		'reverse_order'  => false,
+		'author_text' => esc_html__( 'by', '_s' ),
 	];
 
 	// Parse args.
 	$args = wp_parse_args( $args, $defaults );
 
 	?>
-
-	<span class="posted-on">
-		<?php echo esc_html( $args['before_date'] ); ?>
-		<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
-			<time class="entry-date published" datetime="<?php echo esc_attr( get_the_date( DATE_W3C ) ); ?>">
-				<?php echo esc_html( get_the_time( $args['date_format'] ) ); ?>
-			</time>
-		</a>
-
-		<?php if ( isset( $args['display_author'] ) ) : ?>
-			<?php echo esc_html( $args['before_author'] )
-		<?php endif; ?>
+	<span class="post-author">
+		<?php echo esc_html( $args['author_text'] . ' ' ); ?>
+		<span class="author vcard">
+			<a class="url fn n" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>"><?php echo esc_html( get_the_author() ); ?></a>
+		</span>
 	</span>
 
-	 <?php
-		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-		}
-
-		$time_string = sprintf(
-			$time_string,
-			esc_attr( get_the_date( DATE_W3C ) ),
-			esc_html( get_the_date() ),
-			esc_attr( get_the_modified_date( DATE_W3C ) ),
-			esc_html( get_the_modified_date() )
-		);
-
-    $posted_on = sprintf(
-		/* translators: the date the post was published */
-		esc_html_x( 'Posted on %s', 'post date', '_s' ),
-		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
-    );
-
-    $byline = sprintf(
-		/* translators: the post author */
-		esc_html_x( 'by %s', 'post author', '_s' ),
-		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-    );
-
-	 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
-	 echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';
+	<?php
 }
 
 function _s_display_post_meta( $first = 'date', $date_meta = [], $byline_meta = [] ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -24,8 +24,6 @@ function _s_post_date( $args = [] ) {
 
 	// Parse args.
 	$args = wp_parse_args( $args, $defaults );
-
-	ob_start();
 	?>
 	<span class="posted-on">
 		<?php echo esc_html( $args['date_text'] . ' ' ); ?>

--- a/search.php
+++ b/search.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * The search template file.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package _s
+ */
+
+get_header(); ?>
+
+	<main id="main" class="container site-main">
+
+		<?php
+		if ( have_posts() ) :
+			if ( is_home() && ! is_front_page() ) :
+				?>
+				<header>
+					<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
+				</header>
+
+				<?php
+			endif;
+
+			/* Start the Loop */
+			while ( have_posts() ) :
+				the_post();
+
+				get_template_part( 'template-parts/content', 'search' );
+
+			endwhile;
+
+			_s_display_numeric_pagination();
+
+		else :
+			get_template_part( 'template-parts/content', 'none' );
+		endif;
+		?>
+
+	</main><!-- #main -->
+
+<?php get_footer(); ?>

--- a/search.php
+++ b/search.php
@@ -13,14 +13,6 @@ get_header(); ?>
 
 		<?php
 		if ( have_posts() ) :
-			if ( is_home() && ! is_front_page() ) :
-				?>
-				<header>
-					<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
-				</header>
-
-				<?php
-			endif;
 
 			/* Start the Loop */
 			while ( have_posts() ) :

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -16,7 +16,8 @@
 
 			<?php if ( 'post' === get_post_type() ) : ?>
 			<div class="entry-meta">
-				<?php _s_posted_on(); ?>
+				<?php _s_post_date(); ?>
+				<?php _s_post_author(); ?>
 			</div><!-- .entry-meta -->
 			<?php endif; ?>
 		</header><!-- .entry-header -->

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -22,8 +22,8 @@
 			if ( 'post' === get_post_type() ) :
 				?>
 				<div class="entry-meta">
-					<?php _s_posted_on(); ?><br/>
-					<?php _s_posted_on_alt(); ?>
+					<?php _s_post_date(); ?>
+					<?php _s_post_author(); ?>
 				</div><!-- .entry-meta -->
 			<?php endif; ?>
 		</header><!-- .entry-header -->

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -22,7 +22,8 @@
 			if ( 'post' === get_post_type() ) :
 				?>
 				<div class="entry-meta">
-					<?php _s_posted_on(); ?>
+					<?php _s_posted_on(); ?><br/>
+					<?php _s_posted_on_alt(); ?>
 				</div><!-- .entry-meta -->
 			<?php endif; ?>
 		</header><!-- .entry-header -->


### PR DESCRIPTION
Closes #770 

### DESCRIPTION

Refactors the `_s_posted_on()` function to make the code more readable and configurable. This function has been replaced by two new functions: `_s_post_date()` and `_s_post_author()`.

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY

View singles/archives to make sure post dates and authors are being rendered correctly.

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?
