### PR TITLE
Remove vendor/bin prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
 		"wp-coding-standards/wpcs": "^2.3.0"
 	},
 	"scripts": {
-		"format": "./vendor/bin/phpcbf --report=summary,source",
-		"lint": "./vendor/bin/phpcs --report=summary,source",
-		"pot": "./vendor/bin/wp i18n make-pot . build/languages/_s.pot --exclude=node_modules,vendor,build --allow-root"
+		"format": "phpcbf --report=summary,source",
+		"lint": "phpcs --report=summary,source",
+		"pot": "wp i18n make-pot . build/languages/_s.pot --exclude=node_modules,vendor,build --allow-root"
 	}
 }


### PR DESCRIPTION
Closes #779

### DESCRIPTION

- Removed `./vendor/bin/` from composer scripts for maximum compatibility (Windows).

From the [composer documentation](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands):

> Note: Before executing scripts, Composer's bin-dir is temporarily pushed on top of the PATH environment variable so that binaries of dependencies are directly accessible. In this example no matter if the phpunit binary is actually in vendor/bin/phpunit or bin/phpunit it will be found and executed.

### OTHER

- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)

### STEPS TO VERIFY

Run these commands on a vanilla windows install (no powershell, cygwin, etc.):

1. `composer install`
2. `composer run lint`

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)? Nope
