### PR TITLE
Adds fonts back to copyplugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,11 @@ module.exports = {
 					to: 'images/icons/[name][ext]',
 					context: path.resolve( process.cwd(), 'src/images/icons' ),
 				},
+				{
+					from: '**/*.{woff,woff2,eot,ttf,otf}',
+					to: 'fonts/[path][name][ext]',
+					context: path.resolve( process.cwd(), 'src/fonts' ),
+				},
 			],
 		} ),
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,9 +39,9 @@ module.exports = {
 			},
 			{
 				test: /\.(woff|woff2|eot|ttf|otf)$/,
-				type: 'asset',
+				type: 'asset/resource',
 				generator: {
-					filename: 'fonts/[name].[hash:8].[ext]',
+					filename: 'fonts/[name][ext]',
 				},
 			},
 		],
@@ -62,16 +62,19 @@ module.exports = {
 					from: '**/*.{jpg,jpeg,png,gif,svg}',
 					to: 'images/[path][name][ext]',
 					context: path.resolve( process.cwd(), 'src/images' ),
+					noErrorOnMissing: true,
 				},
 				{
 					from: '*.svg',
 					to: 'images/icons/[name][ext]',
 					context: path.resolve( process.cwd(), 'src/images/icons' ),
+					noErrorOnMissing: true,
 				},
 				{
 					from: '**/*.{woff,woff2,eot,ttf,otf}',
 					to: 'fonts/[path][name][ext]',
 					context: path.resolve( process.cwd(), 'src/fonts' ),
+					noErrorOnMissing: true,
 				},
 			],
 		} ),


### PR DESCRIPTION
### DESCRIPTION

In working through #785, I realized fonts weren't being copied to `build` anymore in the `CopyPlugin` plugin. This adds 'em back!

### SCREENSHOTS
<img width="662" alt="image" src="https://user-images.githubusercontent.com/954724/141525394-e7603b57-3243-4013-bbd4-6a2f81bc1917.png">


### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY
1. Add fonts to `src/fonts`
2. Run `npm run build`
3. See fonts in the `build/fonts` directory

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

Don't think so, because this should have been working already (and was before!).