### PR TITLE
Bumps to Tailwind 3.0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "wd_s",
 			"version": "2.1.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
@@ -22,6 +21,7 @@
 				"css-minimizer-webpack-plugin": "^3.4.1",
 				"eslint-plugin-eslint-comments": "^3.2.0",
 				"eslint-webpack-plugin": "^3.1.1",
+				"glob": "^7.1.7",
 				"imagemin-webpack-plugin": "^2.4.2",
 				"mini-css-extract-plugin": "^2.6.0",
 				"npm-run-all": "^4.1.5",
@@ -33,7 +33,7 @@
 				"stylelint-config-prettier": "^9.0.3",
 				"stylelint-webpack-plugin": "^3.2.0",
 				"svg-spritemap-webpack-plugin": "git://github.com/cascornelissen/svg-spritemap-webpack-plugin.git#500280acbf4517319e57e951a44db524060dc105",
-				"tailwindcss": "^2.2.19",
+				"tailwindcss": "^3.0.24",
 				"webpack-cli": "^4.9.2",
 				"webpack-merge": "^5.8.0"
 			},
@@ -4244,6 +4244,8 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
 			"integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -4259,7 +4261,9 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/ajv-keywords": {
 			"version": "3.5.2",
@@ -5991,10 +5995,16 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -6289,16 +6299,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/color": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
-			"integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1",
-				"color-string": "^1.6.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6316,16 +6316,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
-		},
-		"node_modules/color-string": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-			"integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
 		},
 		"node_modules/colord": {
 			"version": "2.7.0",
@@ -7074,12 +7064,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/css-unit-converter": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-			"integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-			"dev": true
 		},
 		"node_modules/css-what": {
 			"version": "5.0.1",
@@ -10681,12 +10665,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/hex-color-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-			"dev": true
-		},
 		"node_modules/homedir-polyfill": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -10703,18 +10681,6 @@
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-			"dev": true
-		},
-		"node_modules/hsl-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-			"dev": true
-		},
-		"node_modules/hsla-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
 		"node_modules/html-element-map": {
@@ -11393,18 +11359,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/import-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
-			"integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
-			"dev": true,
-			"dependencies": {
-				"import-from": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -11428,18 +11382,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/import-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-			"integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-			"dev": true,
-			"dependencies": {
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/import-lazy": {
@@ -11694,33 +11636,10 @@
 				"is-ci": "bin.js"
 			}
 		},
-		"node_modules/is-color-stop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
-			"dev": true,
-			"dependencies": {
-				"css-color-names": "^0.0.4",
-				"hex-color-regex": "^1.1.0",
-				"hsl-regex": "^1.0.0",
-				"hsla-regex": "^1.0.0",
-				"rgb-regex": "^1.0.1",
-				"rgba-regex": "^1.0.0"
-			}
-		},
-		"node_modules/is-color-stop/node_modules/css-color-names": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/is-core-module": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
-			"integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -13433,9 +13352,9 @@
 			}
 		},
 		"node_modules/lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+			"integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -13718,12 +13637,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"node_modules/lodash.topath": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
-			"integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
 			"dev": true
 		},
 		"node_modules/lodash.truncate": {
@@ -14603,18 +14516,6 @@
 				"mkdirp": "bin/cmd.js"
 			}
 		},
-		"node_modules/modern-normalize": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.1.0.tgz",
-			"integrity": "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/moo": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -14733,15 +14634,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"node_modules/node-emoji": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-			"integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-			"dev": true,
-			"dependencies": {
-				"lodash": "^4.17.21"
-			}
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.1",
@@ -15271,9 +15163,9 @@
 			"dev": true
 		},
 		"node_modules/object-hash": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
@@ -16627,20 +16519,22 @@
 			}
 		},
 		"node_modules/postcss-js": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-3.0.3.tgz",
-			"integrity": "sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+			"integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
 			"dev": true,
 			"dependencies": {
-				"camelcase-css": "^2.0.1",
-				"postcss": "^8.1.6"
+				"camelcase-css": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.0"
+				"node": "^12 || ^14 || >= 16"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.3"
 			}
 		},
 		"node_modules/postcss-lab-function": {
@@ -16786,13 +16680,12 @@
 			}
 		},
 		"node_modules/postcss-load-config": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
-			"integrity": "sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
 			"dev": true,
 			"dependencies": {
-				"import-cwd": "^3.0.0",
-				"lilconfig": "^2.0.3",
+				"lilconfig": "^2.0.5",
 				"yaml": "^1.10.2"
 			},
 			"engines": {
@@ -16803,9 +16696,13 @@
 				"url": "https://opencollective.com/postcss/"
 			},
 			"peerDependencies": {
+				"postcss": ">=8.0.9",
 				"ts-node": ">=9.0.0"
 			},
 			"peerDependenciesMeta": {
+				"postcss": {
+					"optional": true
+				},
 				"ts-node": {
 					"optional": true
 				}
@@ -17999,15 +17896,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/pretty-hrtime": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -18201,30 +18089,6 @@
 				"utf-8-validate": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/purgecss": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.0.3.tgz",
-			"integrity": "sha512-PYOIn5ibRIP34PBU9zohUcCI09c7drPJJtTDAc0Q6QlRz2/CHQ8ywGLdE7ZhxU2VTqB7p5wkvj5Qcm05Rz3Jmw==",
-			"dev": true,
-			"dependencies": {
-				"commander": "^6.0.0",
-				"glob": "^7.0.0",
-				"postcss": "^8.2.1",
-				"postcss-selector-parser": "^6.0.2"
-			},
-			"bin": {
-				"purgecss": "bin/purgecss.js"
-			}
-		},
-		"node_modules/purgecss/node_modules/commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/q": {
@@ -18643,22 +18507,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/reduce-css-calc": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-			"integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-			"dev": true,
-			"dependencies": {
-				"css-unit-converter": "^1.1.1",
-				"postcss-value-parser": "^3.3.0"
-			}
-		},
-		"node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-			"dev": true
-		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -18912,13 +18760,17 @@
 			"dev": true
 		},
 		"node_modules/resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.8.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -19029,18 +18881,6 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/rgb-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-			"dev": true
-		},
-		"node_modules/rgba-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
-			"dev": true
 		},
 		"node_modules/rimraf": {
 			"version": "2.7.1",
@@ -19830,21 +19670,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"dev": true
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
 			"dev": true
 		},
 		"node_modules/sirv": {
@@ -21492,6 +21317,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/svg-element-attributes": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/svg-element-attributes/-/svg-element-attributes-1.3.1.tgz",
@@ -21847,43 +21684,33 @@
 			"dev": true
 		},
 		"node_modules/tailwindcss": {
-			"version": "2.2.19",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.19.tgz",
-			"integrity": "sha512-6Ui7JSVtXadtTUo2NtkBBacobzWiQYVjYW0ZnKaP9S1ZCKQ0w7KVNz+YSDI/j7O7KCMHbOkz94ZMQhbT9pOqjw==",
+			"version": "3.0.24",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+			"integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"arg": "^5.0.1",
-				"bytes": "^3.0.0",
-				"chalk": "^4.1.2",
-				"chokidar": "^3.5.2",
-				"color": "^4.0.1",
-				"cosmiconfig": "^7.0.1",
+				"chokidar": "^3.5.3",
+				"color-name": "^1.1.4",
 				"detective": "^5.2.0",
 				"didyoumean": "^1.2.2",
 				"dlv": "^1.1.3",
-				"fast-glob": "^3.2.7",
-				"fs-extra": "^10.0.0",
-				"glob-parent": "^6.0.1",
-				"html-tags": "^3.1.0",
-				"is-color-stop": "^1.1.0",
-				"is-glob": "^4.0.1",
-				"lodash": "^4.17.21",
-				"lodash.topath": "^4.5.2",
-				"modern-normalize": "^1.1.0",
-				"node-emoji": "^1.11.0",
+				"fast-glob": "^3.2.11",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"lilconfig": "^2.0.5",
 				"normalize-path": "^3.0.0",
-				"object-hash": "^2.2.0",
-				"postcss-js": "^3.0.3",
-				"postcss-load-config": "^3.1.0",
+				"object-hash": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss": "^8.4.12",
+				"postcss-js": "^4.0.0",
+				"postcss-load-config": "^3.1.4",
 				"postcss-nested": "5.0.6",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0",
-				"pretty-hrtime": "^1.0.3",
-				"purgecss": "^4.0.3",
+				"postcss-selector-parser": "^6.0.10",
+				"postcss-value-parser": "^4.2.0",
 				"quick-lru": "^5.1.1",
-				"reduce-css-calc": "^2.1.8",
-				"resolve": "^1.20.0",
-				"tmp": "^0.2.1"
+				"resolve": "^1.22.0"
 			},
 			"bin": {
 				"tailwind": "lib/cli.js",
@@ -21893,46 +21720,19 @@
 				"node": ">=12.13.0"
 			},
 			"peerDependencies": {
-				"autoprefixer": "^10.0.2",
 				"postcss": "^8.0.9"
 			}
 		},
-		"node_modules/tailwindcss/node_modules/fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/tailwindcss/node_modules/glob-parent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
-			"integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
 			"dependencies": {
-				"is-glob": "^4.0.1"
+				"is-glob": "^4.0.3"
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/tailwindcss/node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
 			}
 		},
 		"node_modules/tailwindcss/node_modules/quick-lru": {
@@ -21945,15 +21745,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/tailwindcss/node_modules/universalify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/tapable": {
@@ -22324,33 +22115,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dev": true,
-			"dependencies": {
-				"rimraf": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8.17.0"
-			}
-		},
-		"node_modules/tmp/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/tmpl": {
@@ -25402,7 +25166,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.0.tgz",
 			"integrity": "sha512-T5ZyNSw9G0x0UDFiXV40a7VjKw2b+l4G+S0sctKqxhx8cg9QtMUAGwJBVU9mHPDPoZEmwm0tEoukjl4zb9MU7Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.3",
@@ -26703,7 +26468,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
 			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.1",
@@ -26718,7 +26484,8 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
 			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.5",
@@ -26753,7 +26520,8 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
 			"integrity": "sha512-518mL3goaSeXtJCQcPK9OYHUUiA0sjXuoGWHBwRalkyTIQZZy5ZZzlwrlSc9ESZcOw9BZ+Uo8CJRjV2OWnx+Zw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.3.4",
@@ -26896,7 +26664,8 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.1.0.tgz",
 			"integrity": "sha512-FjXL5GbpmI/wXXcpCf2sKosVIVuWjUuHmDbwcMzd0SClcudo9QjDRdVe35We+js8eQLPgB9hsG4Cty6cAFFxsQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wordpress/postcss-plugins-preset": {
 			"version": "3.2.4",
@@ -26912,7 +26681,8 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.2.0.tgz",
 			"integrity": "sha512-/hRr/p5rlSptjg82Mdy5rQ+mvW4GWCoKpe0FHC3oGy+E6SRcYfVGpnGCtmZa4TY69STD+eu59pCTl1J/EgUIUA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wordpress/scripts": {
 			"version": "19.1.0",
@@ -27056,13 +26826,15 @@
 			"version": "1.7.6",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
 			"integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"acorn-node": {
 			"version": "1.8.2",
@@ -27106,22 +26878,22 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
 			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"ajv-formats": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dev": true,
-			"requires": {
-				"ajv": "^8.0.0"
-			},
+			"requires": {},
 			"dependencies": {
 				"ajv": {
-					"version": "8.8.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
+					"version": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
 					"integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
 					"dev": true,
+					"optional": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"json-schema-traverse": "^1.0.0",
@@ -27133,7 +26905,9 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-					"dev": true
+					"dev": true,
+					"optional": true,
+					"peer": true
 				}
 			}
 		},
@@ -27141,7 +26915,8 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -28450,9 +28225,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.2",
@@ -28691,16 +28466,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"color": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
-			"integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^2.0.1",
-				"color-string": "^1.6.0"
-			}
-		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -28715,16 +28480,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
-		},
-		"color-string": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-			"integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
-			"dev": true,
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
 		},
 		"colord": {
 			"version": "2.7.0",
@@ -29222,7 +28977,8 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
 			"integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"css-select": {
 			"version": "4.1.3",
@@ -29260,12 +29016,6 @@
 					"dev": true
 				}
 			}
-		},
-		"css-unit-converter": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-			"integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-			"dev": true
 		},
 		"css-what": {
 			"version": "5.0.1",
@@ -29338,7 +29088,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
 			"integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"csso": {
 			"version": "4.2.0",
@@ -30017,7 +29768,8 @@
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},
@@ -30042,7 +29794,8 @@
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},
@@ -30459,7 +30212,8 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
 			"integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -30760,7 +30514,8 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
 			"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -32008,12 +31763,6 @@
 				}
 			}
 		},
-		"hex-color-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-			"dev": true
-		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -32027,18 +31776,6 @@
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-			"dev": true
-		},
-		"hsl-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-			"dev": true
-		},
-		"hsla-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
 		"html-element-map": {
@@ -32168,7 +31905,8 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -32577,15 +32315,6 @@
 			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
 			"dev": true
 		},
-		"import-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
-			"integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
-			"dev": true,
-			"requires": {
-				"import-from": "^3.0.0"
-			}
-		},
 		"import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -32602,15 +32331,6 @@
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
 				}
-			}
-		},
-		"import-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-			"integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-			"dev": true,
-			"requires": {
-				"resolve-from": "^5.0.0"
 			}
 		},
 		"import-lazy": {
@@ -32801,32 +32521,10 @@
 				"ci-info": "^2.0.0"
 			}
 		},
-		"is-color-stop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
-			"dev": true,
-			"requires": {
-				"css-color-names": "^0.0.4",
-				"hex-color-regex": "^1.1.0",
-				"hsl-regex": "^1.0.0",
-				"hsla-regex": "^1.0.0",
-				"rgb-regex": "^1.0.1",
-				"rgba-regex": "^1.0.0"
-			},
-			"dependencies": {
-				"css-color-names": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-					"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-					"dev": true
-				}
-			}
-		},
 		"is-core-module": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
-			"integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -33619,7 +33317,8 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"jest-regex-util": {
 			"version": "26.0.0",
@@ -34133,9 +33832,9 @@
 			}
 		},
 		"lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+			"integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
 			"dev": true
 		},
 		"limiter": {
@@ -34369,12 +34068,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"lodash.topath": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
-			"integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
 			"dev": true
 		},
 		"lodash.truncate": {
@@ -35037,12 +34730,6 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"modern-normalize": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.1.0.tgz",
-			"integrity": "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==",
-			"dev": true
-		},
 		"moo": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -35137,15 +34824,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"node-emoji": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-			"integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.21"
-			}
 		},
 		"node-fetch": {
 			"version": "2.6.1",
@@ -35563,9 +35241,9 @@
 			"dev": true
 		},
 		"object-hash": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
 			"dev": true
 		},
 		"object-inspect": {
@@ -36320,7 +35998,8 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
 			"integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-custom-properties": {
 			"version": "12.1.7",
@@ -36353,25 +36032,29 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
 			"integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-discard-duplicates": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
 			"integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-discard-empty": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
 			"integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-discard-overridden": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
 			"integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-double-position-gradients": {
 			"version": "3.1.1",
@@ -36414,13 +36097,15 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
 			"integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-gap-properties": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
 			"integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-html": {
 			"version": "0.36.0",
@@ -36526,16 +36211,16 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
 			"integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-js": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-3.0.3.tgz",
-			"integrity": "sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+			"integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
 			"dev": true,
 			"requires": {
-				"camelcase-css": "^2.0.1",
-				"postcss": "^8.1.6"
+				"camelcase-css": "^2.0.1"
 			}
 		},
 		"postcss-lab-function": {
@@ -36644,13 +36329,12 @@
 			}
 		},
 		"postcss-load-config": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
-			"integrity": "sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
 			"dev": true,
 			"requires": {
-				"import-cwd": "^3.0.0",
-				"lilconfig": "^2.0.3",
+				"lilconfig": "^2.0.5",
 				"yaml": "^1.10.2"
 			}
 		},
@@ -36695,13 +36379,15 @@
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
 			"integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-media-minmax": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
 			"integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-media-query-parser": {
 			"version": "0.2.3",
@@ -36780,7 +36466,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -36833,7 +36520,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
 			"integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-normalize-display-values": {
 			"version": "5.0.1",
@@ -36933,13 +36621,15 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
 			"integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-page-break": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
 			"integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-place": {
 			"version": "7.0.4",
@@ -37036,7 +36726,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
 			"integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.1",
@@ -37408,7 +37099,8 @@
 			"version": "0.36.2",
 			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
 			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-unique-selectors": {
 			"version": "5.0.1",
@@ -37465,12 +37157,6 @@
 				"ansi-styles": "^4.0.0",
 				"react-is": "^17.0.1"
 			}
-		},
-		"pretty-hrtime": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
@@ -37620,27 +37306,8 @@
 					"version": "7.4.6",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
 					"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-					"dev": true
-				}
-			}
-		},
-		"purgecss": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.0.3.tgz",
-			"integrity": "sha512-PYOIn5ibRIP34PBU9zohUcCI09c7drPJJtTDAc0Q6QlRz2/CHQ8ywGLdE7ZhxU2VTqB7p5wkvj5Qcm05Rz3Jmw==",
-			"dev": true,
-			"requires": {
-				"commander": "^6.0.0",
-				"glob": "^7.0.0",
-				"postcss": "^8.2.1",
-				"postcss-selector-parser": "^6.0.2"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},
@@ -37969,24 +37636,6 @@
 				"strip-indent": "^3.0.0"
 			}
 		},
-		"reduce-css-calc": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-			"integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-			"dev": true,
-			"requires": {
-				"css-unit-converter": "^1.1.1",
-				"postcss-value-parser": "^3.3.0"
-			},
-			"dependencies": {
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
-				}
-			}
-		},
 		"regenerate": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -38179,13 +37828,14 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.8.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"resolve-bin": {
@@ -38274,18 +37924,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true
-		},
-		"rgb-regex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-			"dev": true
-		},
-		"rgba-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
 			"dev": true
 		},
 		"rimraf": {
@@ -38920,23 +38558,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"dev": true,
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			},
-			"dependencies": {
-				"is-arrayish": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-					"dev": true
-				}
-			}
 		},
 		"sirv": {
 			"version": "1.0.14",
@@ -40019,13 +39640,15 @@
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
 			"integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"stylelint-config-recommended": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
 			"integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"stylelint-config-recommended-scss": {
 			"version": "4.3.0",
@@ -40040,7 +39663,8 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
 					"integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},
@@ -40224,6 +39848,12 @@
 				"has-flag": "^4.0.0",
 				"supports-color": "^7.0.0"
 			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
 		},
 		"svg-element-attributes": {
 			"version": "1.3.1",
@@ -40513,85 +40143,46 @@
 			}
 		},
 		"tailwindcss": {
-			"version": "2.2.19",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.19.tgz",
-			"integrity": "sha512-6Ui7JSVtXadtTUo2NtkBBacobzWiQYVjYW0ZnKaP9S1ZCKQ0w7KVNz+YSDI/j7O7KCMHbOkz94ZMQhbT9pOqjw==",
+			"version": "3.0.24",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+			"integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
 			"dev": true,
 			"requires": {
 				"arg": "^5.0.1",
-				"bytes": "^3.0.0",
-				"chalk": "^4.1.2",
-				"chokidar": "^3.5.2",
-				"color": "^4.0.1",
-				"cosmiconfig": "^7.0.1",
+				"chokidar": "^3.5.3",
+				"color-name": "^1.1.4",
 				"detective": "^5.2.0",
 				"didyoumean": "^1.2.2",
 				"dlv": "^1.1.3",
-				"fast-glob": "^3.2.7",
-				"fs-extra": "^10.0.0",
-				"glob-parent": "^6.0.1",
-				"html-tags": "^3.1.0",
-				"is-color-stop": "^1.1.0",
-				"is-glob": "^4.0.1",
-				"lodash": "^4.17.21",
-				"lodash.topath": "^4.5.2",
-				"modern-normalize": "^1.1.0",
-				"node-emoji": "^1.11.0",
+				"fast-glob": "^3.2.11",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"lilconfig": "^2.0.5",
 				"normalize-path": "^3.0.0",
-				"object-hash": "^2.2.0",
-				"postcss-js": "^3.0.3",
-				"postcss-load-config": "^3.1.0",
+				"object-hash": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss-js": "^4.0.0",
+				"postcss-load-config": "^3.1.4",
 				"postcss-nested": "5.0.6",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0",
-				"pretty-hrtime": "^1.0.3",
-				"purgecss": "^4.0.3",
+				"postcss-selector-parser": "^6.0.10",
+				"postcss-value-parser": "^4.2.0",
 				"quick-lru": "^5.1.1",
-				"reduce-css-calc": "^2.1.8",
-				"resolve": "^1.20.0",
-				"tmp": "^0.2.1"
+				"resolve": "^1.22.0"
 			},
 			"dependencies": {
-				"fs-extra": {
-					"version": "10.0.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-					"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^6.0.1",
-						"universalify": "^2.0.0"
-					}
-				},
 				"glob-parent": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
-					"integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+					"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 					"dev": true,
 					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"jsonfile": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6",
-						"universalify": "^2.0.0"
+						"is-glob": "^4.0.3"
 					}
 				},
 				"quick-lru": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
 					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-					"dev": true
-				},
-				"universalify": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
@@ -40887,26 +40478,6 @@
 					"dev": true,
 					"requires": {
 						"side-channel": "^1.0.4"
-					}
-				}
-			}
-		},
-		"tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dev": true,
-			"requires": {
-				"rimraf": "^3.0.0"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
 					}
 				}
 			}
@@ -42027,7 +41598,8 @@
 			"version": "7.5.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
 			"integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"packages-update": "wp-scripts packages-update",
 		"postinstall": "composer install --quiet && npm run build",
 		"start": "cross-env NODE_ENV=development wp-scripts start",
-		"sync": "browser-sync start --https --proxy 'https://wp-pre-fse.test/' --no-open --files 'build/*.*, **/*.html, **/*.php, !node_modules/**/*.html'",
+		"sync": "browser-sync start --https --proxy 'https://wdunderscores.test' --no-open --files 'build/*.*, **/*.html, **/*.php, !node_modules/**/*.html'",
 		"watch": "run-p start sync"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"css-minimizer-webpack-plugin": "^3.4.1",
 		"eslint-plugin-eslint-comments": "^3.2.0",
 		"eslint-webpack-plugin": "^3.1.1",
+		"glob": "^7.1.7",
 		"imagemin-webpack-plugin": "^2.4.2",
 		"mini-css-extract-plugin": "^2.6.0",
 		"npm-run-all": "^4.1.5",
@@ -46,7 +47,7 @@
 		"stylelint-config-prettier": "^9.0.3",
 		"stylelint-webpack-plugin": "^3.2.0",
 		"svg-spritemap-webpack-plugin": "git://github.com/cascornelissen/svg-spritemap-webpack-plugin.git#500280acbf4517319e57e951a44db524060dc105",
-		"tailwindcss": "^2.2.19",
+		"tailwindcss": "^3.0.24",
 		"webpack-cli": "^4.9.2",
 		"webpack-merge": "^5.8.0"
 	},
@@ -70,7 +71,7 @@
 		"packages-update": "wp-scripts packages-update",
 		"postinstall": "composer install --quiet && npm run build",
 		"start": "cross-env NODE_ENV=development wp-scripts start",
-		"sync": "browser-sync start --https --proxy 'https://wdunderscores.test' --no-open --files 'build/*.*, **/*.html, **/*.php, !node_modules/**/*.html'",
+		"sync": "browser-sync start --https --proxy 'https://wp-pre-fse.test/' --no-open --files 'build/*.*, **/*.html, **/*.php, !node_modules/**/*.html'",
 		"watch": "run-p start sync"
 	}
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,16 @@
 const plugin = require( 'tailwindcss/plugin' );
+const glob = require( 'glob' );
+
+// Get arrays of all of the files.
+const topLevelPhpFiles = glob.sync( './*.php' ),
+	directoryFiles = [
+		'./inc/*.php',
+		'./template-parts/*.php',
+		'./src/js/**/*.js',
+	];
 
 module.exports = {
-	purge: {
-		content: [ './**/*.php', './src/js/**/*.js' ],
-		layers: [ 'utilities' ],
-		mode: 'layers',
-	},
+	content: topLevelPhpFiles.concat( directoryFiles ),
 	theme: {
 		fontSize: {
 			'root-em': '16px',


### PR DESCRIPTION
Closes #804

### DESCRIPTION
Bumps to the latest Tailwind and brings over the additional updates noted in #804 to move us out of Tailwind 2.0.

### SCREENSHOTS
<img width="593" alt="tailwind config updates" src="https://user-images.githubusercontent.com/954724/167640518-5aa36701-8163-4f6e-b0f7-b750a2fcfc63.png">
<img width="844" alt="package.json file updates" src="https://user-images.githubusercontent.com/954724/167640634-bc333af8-2125-4c52-8009-545ff4b28749.png">

Sourcemaps:
<img width="1121" alt="sourcemaps displayed in local install" src="https://user-images.githubusercontent.com/954724/167640746-fe241199-47f4-46de-9ef2-fa682bb46064.png">

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY
- Check out
- `npm i`
- Run `start`, `watch`, `build`, `lint`, and `format` while making updates to ensure the frontend is updated and continues working

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?

I'll need to make a couple of changes to our wiki page on Tailwind config, but otherwise things continue to operate as usual without any changes in workflow.
