### PR TITLE
chore: Update for Composer 2.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,14 @@
 	"config": {
 		"platform": {
 			"php": "7.4"
+		},
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
 	"require": {
-		"composer/installers": "^1.11.0"
+		"composer/installers": "^2.0.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,43 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf32cbc65cf41465cbdec389415800f8",
+    "content-hash": "3878e13a96c4c2cb0b5e6275b436cc5f",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.11.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "ae03311f45dfe194412081526be2e003960df74b"
+                "reference": "af93ba6e52236418f07a278033eba6959ee5b983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
-                "reference": "ae03311f45dfe194412081526be2e003960df74b",
+                "url": "https://api.github.com/repos/composer/installers/zipball/af93ba6e52236418f07a278033eba6959ee5b983",
+                "reference": "af93ba6e52236418f07a278033eba6959ee5b983",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0"
-            },
-            "replace": {
-                "roundcube/plugin-installer": "*",
-                "shama/baton": "*"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "composer/composer": "1.6.* || ^2.0",
                 "composer/semver": "^1 || ^3",
                 "phpstan/phpstan": "^0.12.55",
                 "phpstan/phpstan-phpunit": "^0.12.16",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.3"
+                "symfony/phpunit-bridge": "^5.3",
+                "symfony/process": "^5"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
+                    "dev-main": "2.x-dev"
+                },
+                "plugin-modifies-install-path": true
             },
             "autoload": {
                 "psr-4": {
@@ -61,7 +59,6 @@
             "description": "A multi-framework Composer library installer",
             "homepage": "https://composer.github.io/installers/",
             "keywords": [
-                "Craft",
                 "Dolibarr",
                 "Eliasis",
                 "Hurad",
@@ -82,7 +79,6 @@
                 "Whmcs",
                 "WolfCMS",
                 "agl",
-                "aimeos",
                 "annotatecms",
                 "attogram",
                 "bitrix",
@@ -101,7 +97,6 @@
                 "grav",
                 "installer",
                 "itop",
-                "joomla",
                 "known",
                 "kohana",
                 "laravel",
@@ -116,6 +111,7 @@
                 "modx",
                 "moodle",
                 "osclass",
+                "pantheon",
                 "phpbb",
                 "piwik",
                 "ppi",
@@ -128,9 +124,7 @@
                 "silverstripe",
                 "sydes",
                 "sylius",
-                "symfony",
                 "tastyigniter",
-                "typo3",
                 "wordpress",
                 "yawik",
                 "zend",
@@ -138,7 +132,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.11.0"
+                "source": "https://github.com/composer/installers/tree/v2.1.1"
             },
             "funding": [
                 {
@@ -154,7 +148,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-28T06:42:17+00:00"
+            "time": "2022-04-13T09:13:00+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Closes: No issue, just a free form PR.

### DESCRIPTION

Bump the Composer installer to ^2.0.0 and added the new [allow-plugins](https://getcomposer.org/doc/06-config.md#allow-plugins) that Composer generates on running `composer install`.

### SCREENSHOTS

![image](https://user-images.githubusercontent.com/1461585/169569891-fe871cb3-3ef9-4136-8ea3-c79e7fa86674.png)

![image](https://user-images.githubusercontent.com/1461585/169570174-9d71fd36-fc3c-46a1-9aeb-af38eec1cf9b.png)

this seems to include some small translation warnings not related to the Composer 2 update (it might actually be related to the fact that these comments contain a comma for grammar or some other formatting thing):
![image](https://user-images.githubusercontent.com/1461585/169570522-4ad5721f-8572-46d8-a2c1-16c301086742.png)

![image](https://user-images.githubusercontent.com/1461585/169570709-b4724efa-3763-43ab-b531-75f9faca2b84.png)

![image](https://user-images.githubusercontent.com/1461585/169570804-aa3fb53a-7724-4470-8835-3ce03d6953b7.png)

### OTHER

- [N/A] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [N/A] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [N/A] Does this pass CBT?

### STEPS TO VERIFY

Ensure you are on a version of Composer 2 (`composer self-update --2` if you need to) and make sure `composer install` works and installs everything properly.

### DOCUMENTATION

It might be worthwhile adding some Composer documentation to the Wiki, since there currently is none as far as I can tell.
