### PR TITLE
Add svg-transform-loader support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "wd_s",
 			"version": "2.1.0",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
@@ -34,6 +35,7 @@
 				"stylelint-config-prettier": "^9.0.3",
 				"stylelint-webpack-plugin": "^3.2.0",
 				"svg-spritemap-webpack-plugin": "git://github.com/cascornelissen/svg-spritemap-webpack-plugin.git#500280acbf4517319e57e951a44db524060dc105",
+				"svg-transform-loader": "^2.0.13",
 				"tailwindcss": "^3.0.24",
 				"webpack-cli": "^4.9.2",
 				"webpack-merge": "^5.8.0"
@@ -7206,6 +7208,15 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
+		"node_modules/clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/clone-deep": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -7300,6 +7311,15 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
+		},
+		"node_modules/color-parse": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+			"integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "^1.0.0"
+			}
 		},
 		"node_modules/colord": {
 			"version": "2.9.2",
@@ -9417,6 +9437,18 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
 		},
+		"node_modules/errno": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+			"dev": true,
+			"dependencies": {
+				"prr": "~1.0.1"
+			},
+			"bin": {
+				"errno": "cli.js"
+			}
+		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -11169,6 +11201,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/finalhandler": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
@@ -11414,6 +11455,13 @@
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+			"dev": true
+		},
+		"node_modules/flatten": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+			"integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
+			"deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
@@ -13166,6 +13214,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/indexes-of": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+			"dev": true
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
@@ -16479,6 +16533,12 @@
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
+		"node_modules/lodash.isempty": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+			"integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
+			"dev": true
+		},
 		"node_modules/lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -17172,6 +17232,16 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"dev": true,
+			"dependencies": {
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
+			}
+		},
 		"node_modules/memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -17237,6 +17307,18 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
 			"dev": true
+		},
+		"node_modules/merge-options": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+			"integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+			"dev": true,
+			"dependencies": {
+				"is-plain-obj": "^1.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
@@ -19359,6 +19441,18 @@
 				"postcss": "^8.4"
 			}
 		},
+		"node_modules/postcss-helpers": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/postcss-helpers/-/postcss-helpers-0.3.2.tgz",
+			"integrity": "sha512-hppnMXY6Ehe8CgLHQCDWbyUsXvBFggdzftWzznL65MhgZsE8o8pUTYbmUbLst0rps+wyUSLIUJ0bGpV2Tzv7lw==",
+			"dev": true,
+			"dependencies": {
+				"urijs": "^1.18.12"
+			},
+			"engines": {
+				"node": ">=0.12.9"
+			}
+		},
 		"node_modules/postcss-image-set-function": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.6.tgz",
@@ -20160,6 +20254,215 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true
 		},
+		"node_modules/postcss-values-parser": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
+			"integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
+			"dev": true,
+			"dependencies": {
+				"flatten": "^1.0.2",
+				"indexes-of": "^1.0.1",
+				"uniq": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/posthtml": {
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.11.6.tgz",
+			"integrity": "sha512-C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==",
+			"dev": true,
+			"dependencies": {
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/posthtml-match-helper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/posthtml-match-helper/-/posthtml-match-helper-1.0.3.tgz",
+			"integrity": "sha512-aeRAPvok2Fs6uzSm85665jdAk5UOd8US2QCkWtGU6yLPlKSwzWTSgZZuABc3UeNy3K1lVk/HV9bRkWJYN05Ymw==",
+			"dev": true,
+			"peerDependencies": {
+				"posthtml": ">=0.5.0"
+			}
+		},
+		"node_modules/posthtml-parser": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.2.tgz",
+			"integrity": "sha512-BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==",
+			"dev": true,
+			"dependencies": {
+				"htmlparser2": "^3.9.2"
+			}
+		},
+		"node_modules/posthtml-parser/node_modules/dom-serializer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.0.1",
+				"entities": "^2.0.0"
+			}
+		},
+		"node_modules/posthtml-parser/node_modules/dom-serializer/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			]
+		},
+		"node_modules/posthtml-parser/node_modules/dom-serializer/node_modules/entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/posthtml-parser/node_modules/domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+			"dev": true
+		},
+		"node_modules/posthtml-parser/node_modules/domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/posthtml-parser/node_modules/domutils": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/posthtml-parser/node_modules/entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+			"dev": true
+		},
+		"node_modules/posthtml-parser/node_modules/htmlparser2": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^1.3.1",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.1.1"
+			}
+		},
+		"node_modules/posthtml-parser/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/posthtml-render": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.4.0.tgz",
+			"integrity": "sha512-W1779iVHGfq0Fvh2PROhCe2QhB8mEErgqzo1wpIt36tCgChafP+hbXIhLDOM8ePJrZcFs0vkNEtdibEWVqChqw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/posthtml-transform": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/posthtml-transform/-/posthtml-transform-1.0.10.tgz",
+			"integrity": "sha512-z45ehCxEh+kd9Ass6iULR42xklSTfhvrGaV0wJTi1QfAonWyMFTRAI9I/XNTuJsY8ljAFBYhCDzxEqqMevlyuw==",
+			"dev": true,
+			"dependencies": {
+				"color-parse": "^1.3.7",
+				"loader-utils": "^1.1.0",
+				"lodash": "^4.17.14",
+				"postcss-values-parser": "^1.5.0",
+				"posthtml": "^0.11.3",
+				"posthtml-match-helper": "^1.0.1",
+				"slashes": "^1.0.5",
+				"unquote": "^1.1.1"
+			}
+		},
+		"node_modules/posthtml-transform/node_modules/json5": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.0"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			}
+		},
+		"node_modules/posthtml-transform/node_modules/loader-utils": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+			"dev": true,
+			"dependencies": {
+				"big.js": "^5.2.2",
+				"emojis-list": "^3.0.0",
+				"json5": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/postsvg": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/postsvg/-/postsvg-2.2.7.tgz",
+			"integrity": "sha512-TyRnoyEvszrEGOzxaTycnUgJZ0W2Xnd9fOmgfuy61Qjo6JhDPhAIBQ1dspQCvdVpK9KkIlZkSETSjmbO0gVIag==",
+			"dev": true,
+			"dependencies": {
+				"clone": "^1.0.4",
+				"deepmerge": "^2.1.0",
+				"posthtml": "^0.11.3",
+				"posthtml-match-helper": "^1.0.1",
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.2"
+			}
+		},
+		"node_modules/postsvg/node_modules/deepmerge": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+			"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -20309,6 +20612,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true
+		},
+		"node_modules/prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 			"dev": true
 		},
 		"node_modules/pseudomap": {
@@ -20930,6 +21239,12 @@
 			"bin": {
 				"jsesc": "bin/jsesc"
 			}
+		},
+		"node_modules/remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"node_modules/repeat-element": {
 			"version": "1.1.4",
@@ -21792,6 +22107,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/slashes": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/slashes/-/slashes-1.0.5.tgz",
+			"integrity": "sha1-IEeY9sYyAU1gm12JtqV6eq9wgo0=",
+			"dev": true
+		},
 		"node_modules/slice-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -22294,6 +22615,15 @@
 			"dev": true,
 			"bin": {
 				"specificity": "bin/specificity"
+			}
+		},
+		"node_modules/split-on-first": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/split-string": {
@@ -23213,6 +23543,171 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/svg-mixer-utils": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/svg-mixer-utils/-/svg-mixer-utils-0.3.4.tgz",
+			"integrity": "sha512-szkeG+Jn6DRo7QlnUOYKslm4J6dg37I8E+tLG1PB13U6UhSlkC8teCisyT7ZRGRwTcTxmNizvu+/oe8uJUf5EA==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^6.5.1",
+				"anymatch": "^2.0.0",
+				"memory-fs": "^0.4.1",
+				"merge-options": "^1.0.0",
+				"postcss-helpers": "^0.3.2"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"dependencies": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
+			"dependencies": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/braces/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/fill-range/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
+			"dependencies": {
+				"kind-of": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/is-number/node_modules/kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"dependencies": {
+				"is-buffer": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
+			"dependencies": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"dependencies": {
+				"remove-trailing-separator": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-mixer-utils/node_modules/to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"dependencies": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/svg-parser": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
@@ -23305,6 +23800,107 @@
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
 			"dev": true
+		},
+		"node_modules/svg-transform-loader": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/svg-transform-loader/-/svg-transform-loader-2.0.13.tgz",
+			"integrity": "sha512-x3KeCei7aD5BClANdDsO3+yVjWNgb87Hv7tW0TLyuv1Tp6HkOEBesJwI8gBf6aFjpmQFMqgfwUcIFoziEdWnDw==",
+			"dev": true,
+			"dependencies": {
+				"loader-utils": "^1.1.0",
+				"lodash.isempty": "^4.4.0",
+				"merge-options": "^1.0.0",
+				"postcss": "^7.0.14",
+				"posthtml-transform": "^1.0.10",
+				"postsvg": "^2.2.7",
+				"query-string": "^6.1.0",
+				"svg-mixer-utils": "^0.3.4"
+			}
+		},
+		"node_modules/svg-transform-loader/node_modules/json5": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.0"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			}
+		},
+		"node_modules/svg-transform-loader/node_modules/loader-utils": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+			"dev": true,
+			"dependencies": {
+				"big.js": "^5.2.2",
+				"emojis-list": "^3.0.0",
+				"json5": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/svg-transform-loader/node_modules/picocolors": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+			"dev": true
+		},
+		"node_modules/svg-transform-loader/node_modules/postcss": {
+			"version": "7.0.39",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+			"dev": true,
+			"dependencies": {
+				"picocolors": "^0.2.1",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			}
+		},
+		"node_modules/svg-transform-loader/node_modules/query-string": {
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+			"integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+			"dev": true,
+			"dependencies": {
+				"decode-uri-component": "^0.2.0",
+				"filter-obj": "^1.1.0",
+				"split-on-first": "^1.0.0",
+				"strict-uri-encode": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/svg-transform-loader/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svg-transform-loader/node_modules/strict-uri-encode": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+			"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/svg4everybody": {
 			"version": "2.1.9",
@@ -24201,6 +24797,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/uniq": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+			"dev": true
+		},
 		"node_modules/universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -24281,6 +24883,12 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"node_modules/urijs": {
+			"version": "1.19.11",
+			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+			"integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+			"dev": true
 		},
 		"node_modules/urix": {
 			"version": "0.1.0",
@@ -26843,15 +27451,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.1.tgz",
 			"integrity": "sha512-f1G1WGDXEU/RN1TWAxBPQgQudtLnLQPyiWdtypkPC+mVYNKFKH/HYXSxH4MVNqwF8M0eDsoiU7HumJHCg/L/jg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/selector-specificity": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-1.0.0.tgz",
 			"integrity": "sha512-RkYG5KiGNX0fJ5YoI0f4Wfq2Yo74D25Hru4fxTOioYdQvHBxcrrtTTyT5Ozzh2ejcNrhFy7IEts2WyEY7yi5yw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.7",
@@ -27669,57 +28275,49 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.0.0.tgz",
 			"integrity": "sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-attribute": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.0.0.tgz",
 			"integrity": "sha512-aVdtfx9jlaaxc3unA6l+M9YRnKIZjOhQPthLKqmTXC8UVkBLDRGwPKo+r8n3VZN8B34+yVajzPTZ+ptTSuZZCw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-empty-expression": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.0.0.tgz",
 			"integrity": "sha512-Ccj42ApsePD451AZJJf1QzTD1B/BOU392URJTeXFxSK709i0KUsGtbwyiqsKu7vsYxpTM0IA5clAKDyf9RCZyA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-plugin-replace-jsx-attribute-value": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.0.0.tgz",
 			"integrity": "sha512-88V26WGyt1Sfd1emBYmBJRWMmgarrExpKNVmI9vVozha4kqs6FzQJ/Kp5+EYli1apgX44518/0+t9+NU36lThQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-plugin-svg-dynamic-title": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.0.0.tgz",
 			"integrity": "sha512-F7YXNLfGze+xv0KMQxrl2vkNbI9kzT9oDK55/kUuymh1ACyXkMV+VZWX1zEhSTfEKh7VkHVZGmVtHg8eTZ6PRg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-plugin-svg-em-dimensions": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.0.0.tgz",
 			"integrity": "sha512-+rghFXxdIqJNLQK08kwPBD3Z22/0b2tEZ9lKiL/yTfuyj1wW8HUXu4bo/XkogATIYuXSghVQOOCwURXzHGKyZA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-plugin-transform-react-native-svg": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.0.0.tgz",
 			"integrity": "sha512-VaphyHZ+xIKv5v0K0HCzyfAaLhPGJXSk2HkpYfXIOKb7DjLBv0soHDxNv6X0vr2titsxE7klb++u7iOf7TSrFQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-plugin-transform-svg-component": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.2.0.tgz",
 			"integrity": "sha512-bhYIpsORb++wpsp91fymbFkf09Z/YEKR0DnFjxvN+8JHeCUD2unnh18jIMKnDJTWtvpTaGYPXELVe4OOzFI0xg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@svgr/babel-preset": {
 			"version": "6.2.0",
@@ -28625,8 +29223,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
 			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.1",
@@ -28641,8 +29238,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
 			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.7",
@@ -28674,8 +29270,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.2.tgz",
 			"integrity": "sha512-oMJnM3cJlu1hQMO4XmTFDhNPclj0cLRIeV5Y6uIF/9oNhhSfaMFu+ty0B4zBYodqwes/vbndwRg4j2q2bhG/Dg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.11.0",
@@ -28795,8 +29390,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.1.2.tgz",
 			"integrity": "sha512-Cq1qoSqt+nF2KOkzyH141YnHEnmd5jDRNbCmyC4lkofy6Qxpl4cVwFDX1dZ4S9WVjqqbLp3CEgRKxUzehyGInA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
 			"version": "3.8.0",
@@ -28812,8 +29406,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.3.0.tgz",
 			"integrity": "sha512-eMoGXob2adaKqaVXBiGQ7Hp97pnRSLty4yWydIq8DL9ZC5z9GpWpOq7IB8iPc6QwvLszjfcs+h/rjsr2GZYkvA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/scripts": {
 			"version": "23.1.0",
@@ -29150,15 +29743,13 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-node": {
 			"version": "1.8.2",
@@ -29216,8 +29807,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
 			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ajv-formats": {
 			"version": "2.1.1",
@@ -29252,8 +29842,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "4.3.2",
@@ -30702,6 +31291,12 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"dev": true
+		},
 		"clone-deep": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -30780,6 +31375,15 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
+		},
+		"color-parse": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+			"integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+			"dev": true,
+			"requires": {
+				"color-name": "^1.0.0"
+			}
 		},
 		"colord": {
 			"version": "2.9.2",
@@ -31213,8 +31817,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
 			"integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"css-functions-list": {
 			"version": "3.0.1",
@@ -31338,8 +31941,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
 			"integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"css-select": {
 			"version": "4.3.0",
@@ -31448,8 +32050,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
 			"integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"csso": {
 			"version": "4.2.0",
@@ -32244,8 +32845,7 @@
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -32266,8 +32866,7 @@
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -32356,6 +32955,15 @@
 					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 					"dev": true
 				}
+			}
+		},
+		"errno": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+			"dev": true,
+			"requires": {
+				"prr": "~1.0.1"
 			}
 		},
 		"error-ex": {
@@ -32703,8 +33311,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -32987,8 +33594,7 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
 			"integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -33695,6 +34301,12 @@
 				"to-regex-range": "^5.0.1"
 			}
 		},
+		"filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+			"dev": true
+		},
 		"finalhandler": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
@@ -33883,6 +34495,12 @@
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+			"dev": true
+		},
+		"flatten": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+			"integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
 			"dev": true
 		},
 		"follow-redirects": {
@@ -34630,8 +35248,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -35225,6 +35842,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
 			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true
+		},
+		"indexes-of": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
 			"dev": true
 		},
 		"inflight": {
@@ -36630,8 +37253,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "27.5.1",
@@ -37696,6 +38318,12 @@
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
+		"lodash.isempty": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+			"integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
+			"dev": true
+		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -38233,6 +38861,16 @@
 				"fs-monkey": "1.0.3"
 			}
 		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"dev": true,
+			"requires": {
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
+			}
+		},
 		"memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -38282,6 +38920,15 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
 			"dev": true
+		},
+		"merge-options": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+			"integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+			"dev": true,
+			"requires": {
+				"is-plain-obj": "^1.1"
+			}
 		},
 		"merge-stream": {
 			"version": "2.0.0",
@@ -39713,8 +40360,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
 			"integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-custom-properties": {
 			"version": "12.1.7",
@@ -39747,29 +40393,25 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
 			"integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-discard-duplicates": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
 			"integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-discard-empty": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
 			"integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-discard-overridden": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
 			"integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-double-position-gradients": {
 			"version": "3.1.1",
@@ -39812,15 +40454,22 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
 			"integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-gap-properties": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
 			"integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
+			"dev": true
+		},
+		"postcss-helpers": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/postcss-helpers/-/postcss-helpers-0.3.2.tgz",
+			"integrity": "sha512-hppnMXY6Ehe8CgLHQCDWbyUsXvBFggdzftWzznL65MhgZsE8o8pUTYbmUbLst0rps+wyUSLIUJ0bGpV2Tzv7lw==",
 			"dev": true,
-			"requires": {}
+			"requires": {
+				"urijs": "^1.18.12"
+			}
 		},
 		"postcss-image-set-function": {
 			"version": "4.0.6",
@@ -39835,8 +40484,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
 			"integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-js": {
 			"version": "4.0.0",
@@ -39908,15 +40556,13 @@
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
 			"integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-media-minmax": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
 			"integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-media-query-parser": {
 			"version": "0.2.3",
@@ -39990,8 +40636,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -40045,8 +40690,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
 			"integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-normalize-display-values": {
 			"version": "5.1.0",
@@ -40142,15 +40786,13 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
 			"integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-page-break": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
 			"integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-place": {
 			"version": "7.0.4",
@@ -40247,8 +40889,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
 			"integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.1",
@@ -40260,15 +40901,13 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-scss": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
 			"integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-selector-not": {
 			"version": "5.0.0",
@@ -40313,6 +40952,190 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true
+		},
+		"postcss-values-parser": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
+			"integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
+			"dev": true,
+			"requires": {
+				"flatten": "^1.0.2",
+				"indexes-of": "^1.0.1",
+				"uniq": "^1.0.1"
+			}
+		},
+		"posthtml": {
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.11.6.tgz",
+			"integrity": "sha512-C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==",
+			"dev": true,
+			"requires": {
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.5"
+			}
+		},
+		"posthtml-match-helper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/posthtml-match-helper/-/posthtml-match-helper-1.0.3.tgz",
+			"integrity": "sha512-aeRAPvok2Fs6uzSm85665jdAk5UOd8US2QCkWtGU6yLPlKSwzWTSgZZuABc3UeNy3K1lVk/HV9bRkWJYN05Ymw==",
+			"dev": true
+		},
+		"posthtml-parser": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.2.tgz",
+			"integrity": "sha512-BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "^3.9.2"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+					"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"entities": "^2.0.0"
+					},
+					"dependencies": {
+						"domelementtype": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+							"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+							"dev": true
+						},
+						"entities": {
+							"version": "2.2.0",
+							"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+							"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+							"dev": true
+						}
+					}
+				},
+				"domelementtype": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+					"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+					"dev": true
+				},
+				"domhandler": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+					"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "1"
+					}
+				},
+				"domutils": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+					"dev": true,
+					"requires": {
+						"dom-serializer": "0",
+						"domelementtype": "1"
+					}
+				},
+				"entities": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+					"dev": true
+				},
+				"htmlparser2": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+					"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^1.3.1",
+						"domhandler": "^2.3.0",
+						"domutils": "^1.5.1",
+						"entities": "^1.1.1",
+						"inherits": "^2.0.1",
+						"readable-stream": "^3.1.1"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"posthtml-render": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.4.0.tgz",
+			"integrity": "sha512-W1779iVHGfq0Fvh2PROhCe2QhB8mEErgqzo1wpIt36tCgChafP+hbXIhLDOM8ePJrZcFs0vkNEtdibEWVqChqw==",
+			"dev": true
+		},
+		"posthtml-transform": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/posthtml-transform/-/posthtml-transform-1.0.10.tgz",
+			"integrity": "sha512-z45ehCxEh+kd9Ass6iULR42xklSTfhvrGaV0wJTi1QfAonWyMFTRAI9I/XNTuJsY8ljAFBYhCDzxEqqMevlyuw==",
+			"dev": true,
+			"requires": {
+				"color-parse": "^1.3.7",
+				"loader-utils": "^1.1.0",
+				"lodash": "^4.17.14",
+				"postcss-values-parser": "^1.5.0",
+				"posthtml": "^0.11.3",
+				"posthtml-match-helper": "^1.0.1",
+				"slashes": "^1.0.5",
+				"unquote": "^1.1.1"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				}
+			}
+		},
+		"postsvg": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/postsvg/-/postsvg-2.2.7.tgz",
+			"integrity": "sha512-TyRnoyEvszrEGOzxaTycnUgJZ0W2Xnd9fOmgfuy61Qjo6JhDPhAIBQ1dspQCvdVpK9KkIlZkSETSjmbO0gVIag==",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.4",
+				"deepmerge": "^2.1.0",
+				"posthtml": "^0.11.3",
+				"posthtml-match-helper": "^1.0.1",
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.2"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+					"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+					"dev": true
+				}
+			}
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -40431,6 +41254,12 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
+		"prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+			"dev": true
+		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -40506,8 +41335,7 @@
 					"version": "8.5.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
 					"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -40899,6 +41727,12 @@
 					"dev": true
 				}
 			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.4",
@@ -41576,6 +42410,12 @@
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
+		"slashes": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/slashes/-/slashes-1.0.5.tgz",
+			"integrity": "sha1-IEeY9sYyAU1gm12JtqV6eq9wgo0=",
+			"dev": true
+		},
 		"slice-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -41994,6 +42834,12 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
 			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+			"dev": true
+		},
+		"split-on-first": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
 			"dev": true
 		},
 		"split-string": {
@@ -42553,15 +43399,13 @@
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
 			"integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
 			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
 			"version": "5.0.2",
@@ -42689,6 +43533,149 @@
 			"integrity": "sha512-Bh05dSOnJBf3miNMqpsormfNtfidA/GxQVakhtn0T4DECWKeXQRQUceYjJ+OxYiiLdGe4Jo9iFV8wICFapFeIA==",
 			"dev": true
 		},
+		"svg-mixer-utils": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/svg-mixer-utils/-/svg-mixer-utils-0.3.4.tgz",
+			"integrity": "sha512-szkeG+Jn6DRo7QlnUOYKslm4J6dg37I8E+tLG1PB13U6UhSlkC8teCisyT7ZRGRwTcTxmNizvu+/oe8uJUf5EA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.5.1",
+				"anymatch": "^2.0.0",
+				"memory-fs": "^0.4.1",
+				"merge-options": "^1.0.0",
+				"postcss-helpers": "^0.3.2"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.3",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
 		"svg-parser": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
@@ -42758,6 +43745,84 @@
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
 			"dev": true
+		},
+		"svg-transform-loader": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/svg-transform-loader/-/svg-transform-loader-2.0.13.tgz",
+			"integrity": "sha512-x3KeCei7aD5BClANdDsO3+yVjWNgb87Hv7tW0TLyuv1Tp6HkOEBesJwI8gBf6aFjpmQFMqgfwUcIFoziEdWnDw==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^1.1.0",
+				"lodash.isempty": "^4.4.0",
+				"merge-options": "^1.0.0",
+				"postcss": "^7.0.14",
+				"posthtml-transform": "^1.0.10",
+				"postsvg": "^2.2.7",
+				"query-string": "^6.1.0",
+				"svg-mixer-utils": "^0.3.4"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^1.0.1"
+					}
+				},
+				"picocolors": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.39",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+					"dev": true,
+					"requires": {
+						"picocolors": "^0.2.1",
+						"source-map": "^0.6.1"
+					}
+				},
+				"query-string": {
+					"version": "6.14.1",
+					"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+					"integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+					"dev": true,
+					"requires": {
+						"decode-uri-component": "^0.2.0",
+						"filter-obj": "^1.1.0",
+						"split-on-first": "^1.0.0",
+						"strict-uri-encode": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"strict-uri-encode": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+					"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+					"dev": true
+				}
+			}
 		},
 		"svg4everybody": {
 			"version": "2.1.9",
@@ -43448,6 +44513,12 @@
 				"set-value": "^2.0.1"
 			}
 		},
+		"uniq": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+			"dev": true
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -43514,6 +44585,12 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"urijs": {
+			"version": "1.19.11",
+			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+			"integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+			"dev": true
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -44077,8 +45154,7 @@
 					"version": "8.6.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
 					"integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -44262,8 +45338,7 @@
 			"version": "7.5.7",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
 			"integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"stylelint-config-prettier": "^9.0.3",
 		"stylelint-webpack-plugin": "^3.2.0",
 		"svg-spritemap-webpack-plugin": "git://github.com/cascornelissen/svg-spritemap-webpack-plugin.git#500280acbf4517319e57e951a44db524060dc105",
+		"svg-transform-loader": "^2.0.13",
 		"tailwindcss": "^3.0.24",
 		"webpack-cli": "^4.9.2",
 		"webpack-merge": "^5.8.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,12 +34,14 @@ module.exports = {
 					MiniCssExtractPlugin.loader,
 					'css-loader',
 					'postcss-loader',
+					'svg-transform-loader/encode-query',
 					'sass-loader',
 				],
 			},
 			{
 				test: /\.svg$/,
 				type: 'asset/inline',
+				use: 'svg-transform-loader',
 			},
 			{
 				test: /\.(woff|woff2|eot|ttf|otf)$/,


### PR DESCRIPTION
Closes #876

Discussion originated at #875

### DESCRIPTION

**Add [svg-transform-loader](https://www.npmjs.com/package/svg-transform-loader) capabilities to Webpack**

SVG Transform Loader adds support for fill, stroke and other manipulations with SVGs imported from SCSS.

Example: fill SVG with white color

`background: url(../images/icons/icon.svg?fill=#fff);`

Example: stroke SVG with SCSS color variable

`background: url(../images/icons/icon.svg?stroke=#{$stroke-color});`

### OTHER

- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?

### STEPS TO VERIFY

1. Add fill or stroke properties to an SVG imported from SCSS and `npm run start` or `npm run build`. 

Example: modify src/scss/template-tags/_off-canvas.scss  (Line 30/31)
```
background: url(../images/icons/hamburger.svg?stroke=#f00) 50% 50% no-repeat
            transparent;
```

Example: modify src/scss/template-tags/_off-canvas.scss  (Line 53)
```
background-image: url(../images/icons/close.svg?stroke=#f00);
```

### DOCUMENTATION

Suggest adding a section with documentation on usage and example code.