### PR TITLE
Update .prettierrc.js in order to align prettier & stylelint

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,1 +1,11 @@
-module.exports = require( '@wordpress/prettier-config' );
+module.exports = {
+	...require( '@wordpress/prettier-config' ),
+	overrides: [
+		{
+			files: '*.scss',
+			options: {
+				singleQuote: true,
+			},
+		},
+	],
+};

--- a/src/scss/blocks/core/_image.scss
+++ b/src/scss/blocks/core/_image.scss
@@ -15,7 +15,7 @@
 
 	&.alignfull {
 		figcaption {
-			width: calc(100% - 2rem);
+			width: calc( 100% - 2rem );
 		}
 	}
 }

--- a/src/scss/blocks/core/_list.scss
+++ b/src/scss/blocks/core/_list.scss
@@ -3,7 +3,7 @@
 //----------------------------------------
 
 ul {
-	&:not(.menu, .sub-menu) {
+	&:not( .menu, .sub-menu ) {
 		@apply mb-16 list-disc list-inside;
 	}
 }

--- a/src/scss/blocks/core/_table.scss
+++ b/src/scss/blocks/core/_table.scss
@@ -38,7 +38,7 @@
 		&::before {
 			@apply block uppercase;
 
-			content: attr(data-label);
+			content: attr( data-label );
 
 			@screen desktop {
 				@apply hidden;

--- a/src/scss/critical/_menus.scss
+++ b/src/scss/critical/_menus.scss
@@ -13,7 +13,7 @@
 		@apply flex;
 
 		> li {
-			&:not(:last-child) {
+			&:not( :last-child ) {
 				@apply mr-16;
 			}
 		}
@@ -23,7 +23,7 @@
 		@apply bg-white py-8 absolute shadow-md;
 
 		left: -999em;
-		top: theme('spacing.24');
+		top: theme( 'spacing.24' );
 		z-index: 99999;
 
 		li {
@@ -67,7 +67,7 @@
 		a {
 			@apply block w-full;
 
-			min-width: theme('width.192');
+			min-width: theme( 'width.192' );
 		}
 	}
 }
@@ -78,9 +78,9 @@
 .caret-down {
 	@apply block float-right h-full ml-8;
 
-	background: url(../images/icons/caret-down.svg) 50% 50% no-repeat;
+	background: url( ../images/icons/caret-down.svg ) 50% 50% no-repeat;
 	background-size: 100%;
-	width: theme('spacing.8');
+	width: theme( 'spacing.8' );
 }
 
 //-----------------------------------------

--- a/src/scss/critical/_mobile-menus.scss
+++ b/src/scss/critical/_mobile-menus.scss
@@ -62,8 +62,8 @@
 		@apply inline-block relative;
 
 		float: unset;
-		height: theme('height.16');
-		width: theme('width.16');
+		height: theme( 'height.16' );
+		width: theme( 'width.16' );
 		top: -4px;
 	}
 }

--- a/src/scss/template-tags/_forms.scss
+++ b/src/scss/template-tags/_forms.scss
@@ -2,7 +2,7 @@
 // Forms
 //--------------------------------------------------------------
 textarea,
-input:not(.button) {
+input:not( .button ) {
 	@apply bg-black bg-opacity-10 p-8;
 }
 

--- a/src/scss/template-tags/_modals.scss
+++ b/src/scss/template-tags/_modals.scss
@@ -15,7 +15,7 @@
 
 		left: 50%;
 		top: 50%;
-		transform: translate(-50%, -50%);
+		transform: translate( -50%, -50% );
 	}
 
 	.modal-content {

--- a/src/scss/template-tags/_off-canvas.scss
+++ b/src/scss/template-tags/_off-canvas.scss
@@ -27,11 +27,11 @@
 	&-open {
 		@apply bottom-0 right-0 block h-24 p-0 absolute w-24;
 
-		background: url(../images/icons/hamburger.svg) 50% 50% no-repeat
+		background: url( ../images/icons/hamburger.svg ) 50% 50% no-repeat
 			transparent;
 		background-size: 100%;
-		right: theme('spacing.12');
-		top: theme('spacing.12');
+		right: theme( 'spacing.12' );
+		top: theme( 'spacing.12' );
 		z-index: 9999;
 
 		@screen tablet-landscape {
@@ -41,16 +41,16 @@
 		.admin-bar & {
 			@apply absolute;
 
-			top: theme('spacing.48');
+			top: theme( 'spacing.48' );
 		}
 
 		&:focus,
 		&:hover {
-			outline: 2px solid theme('colors.black');
+			outline: 2px solid theme( 'colors.black' );
 		}
 
 		&.is-visible {
-			background-image: url(../images/icons/close.svg);
+			background-image: url( ../images/icons/close.svg );
 		}
 	}
 

--- a/src/scss/templates/_posts.scss
+++ b/src/scss/templates/_posts.scss
@@ -19,7 +19,7 @@
 }
 
 .post-container {
-	&:not(:last-child) {
+	&:not( :last-child ) {
 		@apply mb-16;
 	}
 }
@@ -45,7 +45,7 @@
 }
 
 .updated {
-	&:not(.published) {
+	&:not( .published ) {
 		@apply hidden;
 	}
 }

--- a/src/scss/templates/_scaffolding.scss
+++ b/src/scss/templates/_scaffolding.scss
@@ -191,7 +191,7 @@
 		header {
 			@apply text-center shadow-md items-center text-white flex flex-col justify-center;
 
-			height: calc(100% - 40px);
+			height: calc( 100% - 40px );
 		} // header
 
 		// The swatch <footer>

--- a/src/scss/wordpress-global/_alignment.scss
+++ b/src/scss/wordpress-global/_alignment.scss
@@ -22,5 +22,5 @@
 	margin-left: -50vw;
 
 	// Total width less vertical scroll bar.
-	width: calc(100vw - 8.1px);
+	width: calc( 100vw - 8.1px );
 }


### PR DESCRIPTION
No ticket/issue

### DESCRIPTION

Stylelint, which is using WP code standards, is expecting single-quoted properties in SCSS, along with spaces around those properties. For example, Stylelint will is expecting `top: theme( 'spacing.12' );` instead of `top: theme("spacing.12");`. However, Prettier isn't following those same standards; this overrides Prettier's defaults to align with Stylelint & WP Code Standards.

### SCREENSHOTS

No screenshots.

### OTHER

- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?

### STEPS TO VERIFY

Run `npm run lint` - there should be no errors.
Run `npm run format` - there should be no files reformatted.

### DOCUMENTATION

Will this pull request require updating the wd_s [wiki](https://github.com/WebDevStudios/wd_s/wiki)?
No, this will be run automatically.
