### PR TITLE
Simplify Grid to `.wds-grid` and include as Tailwind plugin

### DIFF
--- a/inc/hooks/main-classes.php
+++ b/inc/hooks/main-classes.php
@@ -18,7 +18,7 @@ namespace WebDevStudios\wd_s;
  */
 function main_classes( $new_classes ) {
 
-	$classes = [ 'site-main', 'wds-fullwidth-grid' ];
+	$classes = [ 'site-main' ];
 
 	if ( ! empty( $new_classes ) ) {
 		$classes = array_merge( $classes, $new_classes );

--- a/src/scss/tailwind.scss
+++ b/src/scss/tailwind.scss
@@ -4,13 +4,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@layer base {
-	.wds-fullwidth-grid {
-		@apply grid;
-
-		.wds-block-grid {
-			@apply container grid grid-cols-12 gap-x-16;
-		}
-	}
-}

--- a/wds.preset.js
+++ b/wds.preset.js
@@ -2,7 +2,7 @@ const plugin = require( 'tailwindcss/plugin' );
 
 // Get arrays of all of the files.
 module.exports = {
-	safelist: [ 'wds-fullwidth-grid', 'wds-block-grid' ],
+	safelist: [ 'wds-grid' ],
 	theme: {
 		fontSize: {
 			'root-em': '16px',
@@ -65,6 +65,7 @@ module.exports = {
 		},
 		screens: {
 			phone: '300px',
+			'max-tablet-portrait': { max: '600px' },
 			'tablet-portrait': '600px',
 			'wp-admin-bar': '783px',
 			'tablet-landscape': '900px',
@@ -172,6 +173,15 @@ module.exports = {
 
 			addComponents( screenReaderText, {
 				variants: [ 'hover', 'active', 'focus' ],
+			} );
+		} ),
+		plugin( function ( { addUtilities } ) {
+			addUtilities( {
+				'.wds-grid': {
+					display: 'grid',
+					gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+					columnGap: '1rem',
+				},
 			} );
 		} ),
 	],


### PR DESCRIPTION
Closes - No issue created. 

### DESCRIPTION

- Simplifies a grid class as `.wds-grid`
- Creates a 12-column grid with 16px (1rem) column gap
- Adds a plugin so that it can be used with `@apply` (ie: `@apply wds-grid`
- Adds `.wds-grid` to the safelist so that it works if using it as an inline class (ie: `class="wds-grid"`)

### SCREENSHOTS
(note, this screenshot has been taken where the grid was customized to be 6 columns & a larger gap)
![image](https://user-images.githubusercontent.com/18194487/197268936-f7f497a9-595f-405a-9d93-8177f1665383.png)

### STEPS TO VERIFY

- Pull the branch
- use a grid as an inline class or with @apply
- verify that it works in either case
