### PR TITLE
Only wrap freeform block when not empty

### DIFF
--- a/inc/hooks/wrap-core-blocks.php
+++ b/inc/hooks/wrap-core-blocks.php
@@ -34,7 +34,7 @@ function wrap_core_blocks( $block_content, $block ) {
 	}
 
 	// The core/freeform block doesn't have a block name. So we need to check for null to wrap it...
-	if ( null === $block['blockName'] ) {
+	if ( null === $block['blockName'] && ! empty( $block_content ) && ! ctype_space( $block_content ) ) {
 		$block_content = '<span class="wp-block-freeform">' . $block_content . '</span>';
 	}
 


### PR DESCRIPTION
Closes #953 

### DESCRIPTION

- Used conditionals to ensure that the freeform block isn't wrapped if it's empty
- reference: https://www.gsarigiannidis.gr/adding-a-div-wrapper-to-gutenberg-s-classic-block/

### SCREENSHOTS
![image](https://user-images.githubusercontent.com/18194487/199517232-69605b71-024e-4abd-8bc3-f41f0f2efe1d.png)


### STEPS TO VERIFY

Create a page or post with some blocks on it. Optionally add a Freeform block. Publish the post or page. Verify that the blocks you've added do not have redundant empty `<span class="wp-block-freeform"> </span>` between them.

### DOCUMENTATION

No documentation required.
