### PR TITLE
Feature/WDSUS-27 Change block category order

### DIFF
--- a/inc/hooks/reorder-block-categories.php
+++ b/inc/hooks/reorder-block-categories.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Register custom block category(ies).
+ *
+ * @package wd_s
+ */
+
+namespace WebDevStudios\wd_s;
+
+/**
+ * Reorders the block categories and adds a custom block category for 'page' post type.
+ *
+ * @param {array}  $categories - The existing array of block categories.
+ * @param {object} $post - The post object being edited.
+ * @returns {array} - The modified array of block categories.
+ *
+ * @author JC Palmes <jc@webdevstudios.com>
+ * @since  2023-06-02
+ */
+function reorder_block_categories( $categories, $post ) {
+	if ( 'page' !== $post->post_type ) {
+		return $categories;
+	}
+
+	$wds_block_category = [
+		'slug'  => 'wds-blocks-category',
+		'title' => __( 'WDS Blocks', 'wd_s' ),
+	];
+
+	array_unshift( $categories, $wds_block_category );
+	return $categories;
+}
+add_filter( 'block_categories', __NAMESPACE__ . '\reorder_block_categories', 10, 2 );

--- a/inc/hooks/reorder-block-categories.php
+++ b/inc/hooks/reorder-block-categories.php
@@ -10,24 +10,25 @@ namespace WebDevStudios\wd_s;
 /**
  * Reorders the block categories and adds a custom block category for 'page' post type.
  *
- * @param {array}  $categories - The existing array of block categories.
- * @param {object} $post - The post object being edited.
+ * @param {array} $categories - The existing array of block categories.
  * @returns {array} - The modified array of block categories.
  *
  * @author JC Palmes <jc@webdevstudios.com>
  * @since  2023-06-02
  */
-function reorder_block_categories( $categories, $post ) {
-	if ( 'page' !== $post->post_type ) {
-		return $categories;
-	}
-
-	$wds_block_category = [
-		'slug'  => 'wds-blocks-category',
+function reorder_block_categories( $categories ) {
+	$custom_block_category = [
+		'slug'  => __( 'wds-blocks-category', 'wd_s' ),
 		'title' => __( 'WDS Blocks', 'wd_s' ),
 	];
 
-	array_unshift( $categories, $wds_block_category );
-	return $categories;
+	$categories_sorted    = [];
+	$categories_sorted[0] = $custom_block_category;
+
+	foreach ( $categories as $category ) {
+		$categories_sorted[] = $category;
+	}
+
+	return $categories_sorted;
 }
-add_filter( 'block_categories', __NAMESPACE__ . '\reorder_block_categories', 10, 2 );
+add_filter( 'block_categories_all', __NAMESPACE__ . '\reorder_block_categories', 10, 2 );


### PR DESCRIPTION
# Closes
WDSUS-27

## What type of PR is this? (put an x to all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Link to test
Local with a custom test block, set to `category` = `wds-blocks-category`

## Description
- Change the order that the custom categories appear in the list so that the WDS Block category shows on top instead of the bottom.

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #WDS-123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings
![Edit-Page-“Sample-Page”-‹-WD_s-Revamp-—-WordPress](https://github.com/WebDevStudios/wd_s/assets/1948204/563afd98-364f-4f25-b048-25f0cb49f8df)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [Confluence](https://webdevstudios.atlassian.net/wiki/spaces/wds1/pages/2988474566/Feature+Documentation)
- [x] 🙅 no documentation needed

## Others

- [ ] 🦮 Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] 🙌 Does this issue pass all the linting? (PHPCS, ESLint, SassLint)

## [optional] Are there any post-deployment tasks we need to perform?
